### PR TITLE
refactor: using InputEvent as a general key input design

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1,0 +1,1 @@
+pub const u8_MAX = 255;

--- a/src/keymap_macos.zig
+++ b/src/keymap_macos.zig
@@ -1,8 +1,83 @@
 const std = @import("std");
+const assert = std.debug.assert;
+
+const constants = @import("constants.zig");
+const u8_MAX = constants.u8_MAX;
+
+const valuesFromEnum = @import("utils.zig").valuesFromEnum;
+const log = @import("utils.zig").log;
 
 pub const KeyError = error{
     UnknownBytes,
 };
+
+// NOTE: ASCII reserves the first 32 code points
+// (numbers 0–31 decimal) and the last one (number 127 decimal) for
+// control characters.
+// From 1-26 it corresponds to A-Z with Ctrl key.
+pub const CharKey = enum(u8) {
+    KeyNull,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+    Escape,
+
+    // Extended character
+    // TODO: How to handle characters with shift? Should they be mapped
+    // into explicit character?
+    Space = 0x20,
+
+    Quote = 0x27,
+    BracketLeft = 0x28,
+    BracketRight = 0x29,
+    Dash = 0x2d,
+    Dot = 0x2e,
+    Slash = 0x2f,
+    Key0 = 0x30,
+    Key1,
+    Key2,
+    Key3,
+    Key4,
+    Key5,
+    Key6,
+    Key7,
+    Key8,
+    Key9,
+    SemiColon = 0x3b,
+    Equal = 0x3d,
+
+    BracketSquareLeft = 0x5b,
+    BackSlash = 0x5c,
+    BracketSquareRight = 0x5d,
+
+    BackQuote = 0x60,
+    Backspace = 0x7f,
+};
+
+const charKeyValues = valuesFromEnum(u8, CharKey);
 
 // Currently using simple key code
 // Consider using InputEvent below for a more generic way
@@ -160,20 +235,117 @@ pub const KeyCode = enum {
     MetaP,
 };
 
-const InputEvent = struct {
-    // Note:
+pub const InputEvent = struct {
+    // ASCII Note:
     // 0_0000001
     // Little Endian
     // [6]Ctrl to be 0
     // [5]Shift to be 0
     // ^[ for Alt/Escape key
+    // 011: no ctrl and shift
+    // 010: no ctrl and yes shift
+    // 001: Use as char extension.
+    // 000: yes ctrl and no shift
+    // Default with Ctrl; 010 to change with Shift; 011 Disable both keys
 
     ctrl: bool,
     alt: bool,
     shift: bool,
     meta: bool,
-    key: KeyCode,
-    raw: u8,
+    key: CharKey,
+    raw: []u8,
+
+    // NOTE: Using pointer for input param as dynamic bytes causing
+    // dereferencing after return.
+    pub fn init(bytes: []const u8) InputEvent {
+        // Put the value(particularlly bytes) into heap memory to ensure
+        // value persist.
+        // NOTE: Accept using external allocator would be a more common way
+        // and makes "the caller owns the returned memory",
+        // but it makes the call more complicated.
+        var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+        const allocator_g = gpa_allocator.allocator();
+        const inputEvent = allocator_g.create(InputEvent) catch @panic("OOM");
+
+        var end_pos: u8 = 0;
+        for (bytes) |byte| {
+            if (byte != u8_MAX) {
+                end_pos += 1;
+            } else {
+                break;
+            }
+        }
+
+        const result = allocator_g.alloc(u8, end_pos) catch @panic("OOM");
+        @memcpy(result[0..end_pos], bytes[0..end_pos]);
+        inputEvent.raw = @constCast(result);
+
+        var alt = false;
+
+        // TODO: Complex handling for non-single byte case
+        // e.g. Alt composite keys
+        var key_byte: u8 = undefined;
+        // TODO: Handle other raw bytes length cases
+        if (inputEvent.raw.len == 1) {
+            key_byte = bytes[0];
+        } else if (inputEvent.raw.len == 2) {
+            // Escape code for alt key in composite keys
+            if (bytes[0] == 0x1b) {
+                alt = true;
+            }
+            key_byte = bytes[1];
+        }
+
+        // TODO: Symbol would be complicated(?)
+        // NOTE: Ctrl-I/J/M/Q maps to another code in macOS
+        var ctrl = (key_byte & 0b1000000) >> 6 == 0;
+        const extend = (key_byte & 0b0100000) >> 5 == 1;
+        var shift = !ctrl and !extend;
+
+        // TODO: Is exceptional a good way?
+        const exceptional_chars = [_]u8{
+            @intFromEnum(CharKey.BracketSquareLeft),
+            @intFromEnum(CharKey.BracketSquareRight),
+            @intFromEnum(CharKey.Backspace),
+        };
+
+        var key_bits_layer: u8 = undefined;
+        if (std.mem.indexOf(u8, &exceptional_chars, &[_]u8{key_byte})) |_| {
+            // For exceptional chars, fix to have shift is false now.
+            shift = false;
+            key_bits_layer = 0b1111111;
+        } else if (ctrl and extend) {
+            // Extend to read another set of printable character
+            key_bits_layer = 0b0111111;
+            ctrl = false;
+        } else {
+            // For 26 Latin character
+            key_bits_layer = 0b0011111;
+        }
+
+        // NOTE: Manual handling to check if the byte returned is in
+        // CharKey enum defination or not as there is no easy handling
+        // using @enumFromInt now. Fallback to null key for undefined
+        // case
+        const _charKey = (key_byte & key_bits_layer);
+        var charKey: CharKey = undefined;
+        if (std.mem.indexOf(u8, charKeyValues, &[_]u8{_charKey})) |_| {
+            charKey = @enumFromInt(_charKey);
+        } else {
+            charKey = .KeyNull;
+        }
+
+        // TODO: Decide the condition of these modifier keys
+        const meta = false;
+
+        inputEvent.ctrl = ctrl;
+        inputEvent.alt = alt;
+        inputEvent.shift = shift;
+        inputEvent.meta = meta;
+        inputEvent.key = charKey;
+
+        return inputEvent.*;
+    }
 };
 
 fn bytesToU32(bytes: []const u8) u32 {
@@ -182,6 +354,15 @@ fn bytesToU32(bytes: []const u8) u32 {
     const byte_u32 = btv(u32, bytes);
 
     return byte_u32;
+}
+
+fn u32ToBytes(str: []const u8) [4]u8 {
+    var byte_out = [4]u8{ u8_MAX, u8_MAX, u8_MAX, u8_MAX };
+    for (str, 0..) |byte, i| {
+        byte_out[i] = byte;
+    }
+
+    return byte_out;
 }
 
 pub fn mapByteToKeyCode(byte: [4]u8) KeyError!KeyCode {
@@ -302,4 +483,63 @@ pub fn mapByteToKeyCode(byte: [4]u8) KeyError!KeyCode {
         bytesToU32("\x1b\x5b\x43\xff") => .ArrowRight,
         else => .A,
     };
+}
+
+test "InputEvent" {
+    const inputEventKeyA = InputEvent.init(&u32ToBytes("\x41\xff\xff\xff"));
+    assert(inputEventKeyA.key == .A);
+    assert(inputEventKeyA.ctrl == false);
+    assert(inputEventKeyA.alt == false);
+    assert(inputEventKeyA.shift == true);
+    assert(std.mem.eql(u8, inputEventKeyA.raw, "\x41"));
+
+    const inputEventKeya = InputEvent.init(&u32ToBytes("\x61\xff\xff\xff"));
+    assert(inputEventKeya.key == .A);
+    assert(inputEventKeya.ctrl == false);
+    assert(inputEventKeya.alt == false);
+    assert(inputEventKeya.shift == false);
+    assert(std.mem.eql(u8, inputEventKeya.raw, "\x61"));
+
+    const inputEventKeyZ = InputEvent.init(&u32ToBytes("\x5a\xff\xff\xff"));
+    assert(inputEventKeyZ.key == .Z);
+    assert(inputEventKeyZ.ctrl == false);
+    assert(inputEventKeyZ.alt == false);
+    assert(inputEventKeyZ.shift == true);
+    assert(std.mem.eql(u8, inputEventKeyZ.raw, "\x5a"));
+
+    const inputEventEof = InputEvent.init(&u32ToBytes("\x04\xff\xff\xff"));
+    assert(inputEventEof.key == .D);
+    assert(inputEventEof.ctrl == true);
+    assert(inputEventEof.alt == false);
+    assert(inputEventEof.shift == false);
+
+    const inputEventEscape = InputEvent.init(&u32ToBytes("\x1b\xff\xff\xff"));
+    assert(inputEventEscape.key == .Escape);
+    assert(inputEventEscape.ctrl == true);
+    assert(inputEventEscape.alt == false);
+    assert(inputEventEscape.shift == false);
+
+    const inputEventEscapeShort = InputEvent.init(&u32ToBytes("\x1b"));
+    assert(inputEventEscapeShort.key == .Escape);
+    assert(std.mem.eql(u8, inputEventEscapeShort.raw, "\x1b"));
+
+    const inputEventKey0Short = InputEvent.init(&u32ToBytes("\x30"));
+    assert(inputEventKey0Short.key == .Key0);
+    assert(std.mem.eql(u8, inputEventKey0Short.raw, "\x30"));
+
+    const inputEventKey9Short = InputEvent.init(&u32ToBytes("\x39"));
+    assert(inputEventKey9Short.key == .Key9);
+    assert(std.mem.eql(u8, inputEventKey9Short.raw, "\x39"));
+
+    const inputEventSpace = InputEvent.init(&u32ToBytes("\x20\xff\xff\xff"));
+    assert(inputEventSpace.key == .Space);
+    assert(std.mem.eql(u8, inputEventSpace.raw, "\x20"));
+
+    const inputEventBackspaceShort = InputEvent.init(&u32ToBytes("\x7f"));
+    assert(inputEventBackspaceShort.key == .Backspace);
+    assert(std.mem.eql(u8, inputEventBackspaceShort.raw, "\x7f"));
+
+    const inputEventMetaN = InputEvent.init(&u32ToBytes("\x1b\x6e\xff\xff"));
+    assert(inputEventMetaN.ctrl == false);
+    assert(inputEventMetaN.alt == true);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,8 @@ const logz = @import("logz");
 
 const utils = @import("utils.zig");
 const keymap = @import("keymap_macos.zig");
+const constants = @import("constants.zig");
+const u8_MAX = constants.u8_MAX;
 
 const ArrayList = std.ArrayList;
 
@@ -14,7 +16,10 @@ const posix = std.posix;
 const cc_VTIME = 5;
 const cc_VMIN = 6;
 const INPUT_INTERVAL_IN_MS = 1000;
-const u8_MAX = 255;
+
+// NOTE: Shall be OS-dependent, to support different emoji it may require
+// to be 8 too.
+const INPUT_BYTE_SIZE = 4;
 
 // This isn't really an error case but a special case to be handled in
 // parsing byte
@@ -22,28 +27,14 @@ const ByteParsingError = error{
     EndOfStream,
 };
 
-fn log(comptime message: []const u8) !void {
-    std.debug.print("[LOG] {s}\n", .{message});
-}
-
-fn log_as_utf8(byte: u8) !void {
-    var byte_out = [4]u8{ 0, 0, 0, 0 };
-    _ = try std.unicode.utf8Encode(byte, &byte_out);
-    std.debug.print("[LOG] {x}\n", .{byte_out});
-}
-
-fn log_pointer(ptr: anytype) !void {
-    std.debug.print("[LOG] {*}\n", .{ptr});
-}
-
 // Currently for macOS. Can this cater for other OS?
 // NOTE: How many bytes to represent an input makes sense?
 // Assume key input are in four bytes now.
 // Case: M-n (2 bytes)
 // Case: Arrow key (3 bytes)
 // Case: F5 (5 bytes)
-fn read(reader: std.fs.File.Reader) [4]u8 {
-    var buffer = [4]u8{ u8_MAX, u8_MAX, u8_MAX, u8_MAX };
+fn read(reader: std.fs.File.Reader) [INPUT_BYTE_SIZE]u8 {
+    var buffer = [INPUT_BYTE_SIZE]u8{ u8_MAX, u8_MAX, u8_MAX, u8_MAX };
 
     _ = reader.read(&buffer) catch |err| switch (err) {
         else => return buffer,
@@ -78,16 +69,16 @@ fn read(reader: std.fs.File.Reader) [4]u8 {
 ///
 /// See tui/input.c and os/input.c for more.
 /// For keycode, see keycodes.h
-/// TODO: Support emoji case, which is not KeyCode actually.
-fn parsing_byte(reader: std.fs.File.Reader) anyerror!keymap.KeyCode {
+fn parsing_byte(reader: std.fs.File.Reader) anyerror!keymap.InputEvent {
     const bytes = read(reader);
-    const keyCode = keymap.mapByteToKeyCode(bytes);
+    const inputEvent = keymap.InputEvent.init(&bytes);
 
-    return keyCode;
+    return inputEvent;
 }
 
 // backspace function aligns both stdout and array list to store byte.
 // wrapped corresponding params into struct later.
+// TODO: For multiple bytes case it is incorrect now, like emoji input.
 fn backspace(stdout: std.fs.File, arrayList: *ArrayList(u8)) !void {
     const stdout_file = stdout.writer();
     var bw = std.io.bufferedWriter(stdout_file);
@@ -258,26 +249,29 @@ pub const Shell = struct {
         var reading = true;
 
         while (reading) {
-            if (parsing_byte(reader)) |keycode| {
+            if (parsing_byte(reader)) |inputEvent| {
                 self.logger.logger()
-                    .fmt("[LOG]", "keycode: {any}", .{keycode})
+                    .fmt("[LOG]", "InputEvent: {any}", .{inputEvent})
                     .level(.Debug)
                     .log();
 
-                if (keycode == .EndOfStream) {
-                    reading = false;
+                if (inputEvent.ctrl) {
+                    if (inputEvent.key == .D) {
+                        reading = false;
 
-                    // TODO: Prevent using error to handle this?
-                    return ByteParsingError.EndOfStream;
+                        // TODO: Prevent using error to handle this?
+                        return ByteParsingError.EndOfStream;
+                    }
                 }
+
                 // Backspace handling
-                if (keycode == .Backspace) {
+                if (inputEvent.key == .Backspace) {
                     if (arrayList.items.len == 0) {
                         continue;
                     }
 
                     try backspace(stdout, &arrayList);
-                } else if (keycode == .Enter) {
+                } else if (inputEvent.ctrl and inputEvent.key == .J) {
                     const input_result = try arrayList.toOwnedSlice();
 
                     // TODO: Shift-RET case is not handled yet. It returns same byte
@@ -296,48 +290,47 @@ pub const Shell = struct {
                     self.*.history_curr = self.*.history.items.len - 1;
 
                     continue;
-                } else if (keycode == .MetaN) {
-                    if (arrayList.items.len != 0) {
-                        try self.*.clearLine(stdout, &arrayList);
-                    }
+                } else if (inputEvent.alt) {
+                    // Fetch history result, the current history cursor
+                    // points to the last one if there is no history
+                    // navigating function run before.
+                    if (inputEvent.key == .N or inputEvent.key == .P) {
+                        if (arrayList.items.len != 0) {
+                            try self.*.clearLine(stdout, &arrayList);
+                        }
 
-                    const history_len = self.*.history.items.len;
-                    if (history_len == 0) {
-                        continue;
-                    }
+                        const history_len = self.*.history.items.len;
+                        if (history_len == 0) {
+                            continue;
+                        }
 
-                    self.*.history_curr += 1;
-                    if (self.*.history_curr == history_len) {
-                        self.*.history_curr -= 1;
-                        continue;
-                    }
+                        // Return the next one
+                        if (inputEvent.key == .N) {
+                            self.*.history_curr += 1;
+                            if (self.*.history_curr == history_len) {
+                                self.*.history_curr -= 1;
+                                continue;
+                            }
+                        }
 
-                    const result = self.*.getHistoryItem(self.*.history_curr);
-                    for (result) |byte| {
-                        try appendByte(stdout, &arrayList, byte);
-                    }
-                } else if (keycode == .MetaP) {
-                    if (arrayList.items.len != 0) {
-                        try self.*.clearLine(stdout, &arrayList);
-                    }
+                        const result = self.*.getHistoryItem(self.*.history_curr);
+                        for (result) |byte| {
+                            try appendByte(stdout, &arrayList, byte);
+                        }
 
-                    const history_len = self.*.history.items.len;
-                    if (history_len == 0) {
-                        continue;
-                    }
-
-                    const result = self.*.getHistoryItem(self.*.history_curr);
-                    if (self.*.history_curr > 0) {
-                        self.*.history_curr -= 1;
-                    }
-
-                    for (result) |byte| {
-                        try appendByte(stdout, &arrayList, byte);
+                        // Set to the previous one
+                        if (inputEvent.key == .P) {
+                            if (self.*.history_curr > 0) {
+                                self.*.history_curr -= 1;
+                            }
+                        }
                     }
                 } else {
                     // NOTE: Show the byte as in non-ECHO mode, part in Shell later
-                    const byte = @tagName(keycode);
-                    try appendByte(stdout, &arrayList, byte[0]);
+                    const bytes = inputEvent.raw;
+                    for (bytes) |byte| {
+                        try appendByte(stdout, &arrayList, byte);
+                    }
                 }
             } else |err| switch (err) {
                 else => |e| return e,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,4 +1,6 @@
-const assert = @import("std").debug.assert;
+const std = @import("std");
+const print = std.debug.print;
+const assert = std.debug.assert;
 
 pub inline fn valuesFromEnum(comptime E: type, comptime enums: type) []const E {
     comptime {
@@ -11,4 +13,12 @@ pub inline fn valuesFromEnum(comptime E: type, comptime enums: type) []const E {
         const final = result;
         return &final;
     }
+}
+
+pub fn log(comptime key: []const u8, message: anytype) void {
+    std.debug.print("[{s}]: {any}\n", .{ key, message });
+}
+
+pub fn log_pointer(ptr: anytype) void {
+    std.debug.print("[POINTER] {*}\n", .{ptr});
 }


### PR DESCRIPTION
`InputEvent` represents how a key input to the program now, it indicates what key is from the input, and the status of other functional keys includes ctrl, alt, shift and meta. It also includes `raw` field which supports to write the representation into buffer.

Provide `CharKey` in enum to support `InputEvent` key fields to indicate what key is actually the input event corresponds to.

Test cases are provided to show how the `InputEvent` is created from bytes result.

 - Replace `KeyCode` into `InputEvent` in `parsing_byte` from input bytes
 - Extract common constants and log functions out