### PR TITLE
feat: provide Reader struct to complete tokenization process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,31 @@ Build script
 ```sh
 zig build
 ```
+
+# Note
+
+Zig requires manual memory management, some memory are required to be freed for better main program and test cases, noticeably the following items
+- ArrayList (by `arrayList.deinit()`)
+- Slice from ArrayList (Could be `allocator.free(SLICE)`, by then the array list is not required to be freed. If it is not wrapped in allocator some manual way shall be used.)
+
+# Patch note
+
+The [regex library](https://github.com/tiehuis/zig-regex) used requires patch in order to support non-capturing group for tokenization process. Please refer to https://github.com/elton2048/zig-regex/tree/feat-complex-group-support
+
+Another fix for allowing repeat tokens shows as follow:
+
+In `src/regex.zig`
+```
+    pub fn isByteClass(re: *const Expr) bool {
+        switch (re.*) {
+            .Literal,
+            .ByteClass,
+            .AnyCharNotNL,
+            // TODO: Don't keep capture here, but allow on repeat operators.
+            .Capture,
++           .Repeat,
+            => return true,
+            else => return false,
+        }
+    }
+```

--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,12 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.addImport("logz", logz.module("logz"));
 
+    const regex = b.dependency("regex", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("regex", regex.module("regex"));
+
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).
@@ -78,6 +84,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    lib_unit_tests.root_module.addImport("logz", logz.module("logz"));
+    lib_unit_tests.root_module.addImport("regex", regex.module("regex"));
+
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const exe_unit_tests = b.addTest(.{
@@ -86,7 +95,18 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    exe_unit_tests.root_module.addImport("logz", logz.module("logz"));
+    exe_unit_tests.root_module.addImport("regex", regex.module("regex"));
+
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    const reader_test = b.addTest(.{
+        .root_source_file = b.path("./src/reader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    reader_test.root_module.addImport("logz", logz.module("logz"));
+    reader_test.root_module.addImport("regex", regex.module("regex"));
 
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
@@ -94,4 +114,5 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&reader_test.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,10 @@
             .url = "https://github.com/karlseguin/log.zig/archive/97d0818270a357d3ce7bc878abc32dc996fe78ff.tar.gz",
             .hash = "1220c032d828e768348b321a79523812be1c4cb27e1eb7ff5df54b573fa131afd448",
         },
+        .regex = .{
+            .url = "../zig-regex",
+            .hash = "1220b0c913700f12e0691d4fcf9773df8568e1a2e0b3a861282d9987bf2c834480f2",
+        },
     },
     .paths = .{
         "",

--- a/src/keymap_macos.zig
+++ b/src/keymap_macos.zig
@@ -57,6 +57,7 @@ pub const CharKey = enum(u8) {
     // TODO: How to handle characters with shift? Should they be mapped
     // into explicit character?
     Space = 0x20,
+    DoubleQuote = 0x22,
 
     Quote = 0x27,
     BracketLeft = 0x28,
@@ -104,6 +105,8 @@ pub const KeyCode = enum {
     BackSlash,
     Backspace,
     BackTick,
+    BracketLeft,
+    BracketRight,
     BracketSquareLeft,
     BracketSquareRight,
     CapsLock,
@@ -171,6 +174,7 @@ pub const KeyCode = enum {
     Spacebar,
     Tab,
     Quote,
+    DoubleQuote,
     WindowsLeft,
     WindowsRight,
 
@@ -434,6 +438,11 @@ pub fn mapByteToKeyCode(byte: [4]u8) KeyError!KeyCode {
         bytesToU32("\x1b\xff\xff\xff") => .Escape,
         bytesToU32("\x20\xff\xff\xff") => .Spacebar,
         // TODO: x21 - x2f
+        bytesToU32("\x22\xff\xff\xff") => .DoubleQuote,
+        bytesToU32("\x27\xff\xff\xff") => .Quote,
+        bytesToU32("\x28\xff\xff\xff") => .BracketLeft,
+        bytesToU32("\x29\xff\xff\xff") => .BracketRight,
+
         bytesToU32("\x30\xff\xff\xff") => .Key0,
         bytesToU32("\x31\xff\xff\xff") => .Key1,
         bytesToU32("\x32\xff\xff\xff") => .Key2,

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+const utils = @import("utils.zig");
+
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+const debug = std.debug;
+const mem = std.mem;
+
+const MalType = @import("reader.zig").MalType;
+
+pub fn pr_str(mal: MalType) []u8 {
+    var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa_allocator.allocator();
+
+    var string = ArrayList(u8).init(allocator);
+    defer string.deinit();
+
+    switch (mal) {
+        .boolean => {},
+        .number => |value| {
+            const result = std.fmt.allocPrint(allocator, "{d}", .{value.value}) catch @panic("allocator error");
+            string.appendSlice(result) catch @panic("allocator error");
+        },
+        .string => |str| {
+            string.appendSlice(str) catch @panic("allocator error");
+        },
+        .list => |list| {
+            string.appendSlice("(") catch @panic("allocator error");
+            for (list.items) |item| {
+                const result = pr_str(item);
+                string.appendSlice(result) catch @panic("allocator error");
+                string.appendSlice(" ") catch @panic("allocator error");
+            }
+            // Remove the last space
+            _ = string.pop();
+            string.appendSlice(")") catch @panic("allocator error");
+        },
+        else => {},
+    }
+
+    return string.toOwnedSlice() catch unreachable;
+}
+
+test "printer" {
+    const allocator = std.testing.allocator;
+
+    // Test for string case
+    {
+        const mal1 = MalType{ .string = "test" };
+
+        const mal1_result = pr_str(mal1);
+        debug.assert(mem.eql(u8, mal1_result, "test"));
+    }
+
+    // Test for list case
+    {
+        var list1 = ArrayList(MalType).init(allocator);
+        defer list1.deinit();
+
+        list1.append(MalType{ .string = "1" }) catch unreachable;
+        list1.append(MalType{ .string = "2" }) catch unreachable;
+
+        const mal2 = MalType{ .list = list1 };
+        const mal2_result = pr_str(mal2);
+
+        debug.assert(mem.eql(u8, mal2_result, "(1 2)"));
+    }
+}

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -1,0 +1,349 @@
+const std = @import("std");
+const regex = @import("regex");
+const logz = @import("logz");
+
+const utils = @import("utils.zig");
+
+const ArrayList = std.ArrayList;
+const debug = std.debug;
+const mem = std.mem;
+
+const Token = []const u8;
+
+const Error = error{
+    Overflow,
+    EOF,
+
+    UnmatchedSExpr,
+};
+
+const SExprStart = '(';
+const SExprEnd = ')';
+
+fn isDigit(char: u8) bool {
+    return char >= '0' and char <= '9';
+}
+
+pub const Number = struct {
+    value: u64,
+};
+
+pub const MalType = union(enum) {
+    boolean: bool,
+    number: Number,
+    string: []const u8,
+    list: ArrayList(MalType),
+
+    SExprEnd,
+    /// Incompleted type from parser
+    Incompleted,
+
+    pub fn deinit(self: MalType) void {
+        switch (self) {
+            .list => |list| {
+                for (list.items) |item| {
+                    item.deinit();
+                }
+                list.deinit();
+            },
+            else => {},
+        }
+    }
+};
+
+pub const List = ArrayList(MalType);
+
+// NOTE: Currently the regex requires fix to allow repeater after pipe('|')
+// char. Check isByteClass method in the library.
+const MAL_REGEX = "[\\s,]*(~@|[\\[\\]\\{\\}\\(\\)'`~\\^@]|\"(?:\\.|[^\"])*\"?|;.*|[^\\s\\[\\]\\{\\}('\"`,;)]*)";
+
+/// Reader object
+pub const Reader = struct {
+    allocator: std.mem.Allocator,
+    tokens: ArrayList(Token),
+    token_curr: usize,
+    ast_root: MalType,
+
+    fn createList(self: Reader) List {
+        const list = List.init(self.allocator);
+
+        errdefer {
+            self.allocator.destroy(list);
+        }
+
+        return list;
+    }
+
+    pub fn deinit(self: *Reader) void {
+        self.tokens.deinit();
+        self.ast_root.deinit();
+        self.allocator.destroy(self);
+    }
+
+    /// Named as "read_str" in the mal doc
+    pub fn init(allocator: std.mem.Allocator, statement: []const u8) *Reader {
+        // var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+        // const allocator = gpa_allocator.allocator();
+
+        const tokens = ArrayList(Token).init(allocator);
+
+        // NOTE: Create a pointer that requires `destroy` afterwards
+        const self = allocator.create(Reader) catch @panic("OOM");
+        self.* = Reader{
+            .allocator = allocator,
+            .tokens = tokens,
+            .token_curr = 0,
+            .ast_root = undefined,
+        };
+
+        self.tokenize(statement);
+
+        const mal_root = self.read_form();
+        self.*.ast_root = mal_root;
+
+        logz.info()
+            .fmt("[LOG]", "MAL head: {any}", .{mal_root})
+            .log();
+
+        return self;
+    }
+
+    /// tokenize reads statement and generate tokens based on tokenizer
+    /// In current case the tokenizer is a regex.
+    fn tokenize(self: *Reader, statement: []const u8) void {
+        const statement_end_pos = statement.len;
+        var statement_curr: usize = 0;
+        // raw_statement indicates part not matched against tokenizer
+        var raw_statement = statement;
+
+        // The regex is constant so no error should be returned. For the
+        // allocator, it should also contain no issue.
+        var mal_regex = regex.Regex.compile(self.allocator, MAL_REGEX) catch unreachable;
+        defer mal_regex.deinit();
+
+        while (statement_curr < statement_end_pos and raw_statement.len > 0) {
+            var captures = regex.Regex.captures(&mal_regex, raw_statement) catch |err| switch (err) {
+                else => return,
+            };
+            defer captures.?.deinit();
+            if (captures) |result| {
+                statement_curr = statement_curr + (result.slots[1] orelse statement_end_pos - 1);
+                raw_statement = statement[statement_curr..];
+
+                // TODO: Handle the potential error
+                // This is different to normal append case as the object pointer
+                // is mutable normally, however this case gets the result
+                // from struct which is const (now). Might need further
+                // check to see if this implemenation is ok or not.
+                @constCast(&self.*.tokens).append(result.sliceAt(1).?) catch unreachable;
+            } else {
+                // No match case
+                statement_curr = statement_end_pos;
+                raw_statement = "";
+            }
+        }
+
+        return;
+    }
+
+    // peek and next error throwing need better consideration.
+    fn peek(self: Reader) !Token {
+        if (self.token_curr >= self.tokens.items.len) {
+            return Error.Overflow;
+        }
+
+        const token = self.tokens.items[self.token_curr];
+        return token;
+    }
+
+    fn next(self: *Reader) !Token {
+        const token = self.peek() catch unreachable;
+        self.token_curr += 1;
+        if (self.token_curr >= self.tokens.items.len) {
+            return Error.EOF;
+        }
+
+        return token;
+    }
+
+    pub fn read_form(self: *Reader) MalType {
+        var mal: MalType = undefined;
+
+        const token = self.peek() catch @panic("Accessing invalid token.");
+        for (token) |char| {
+            // TODO: Currently check only the first char and handle that
+            // This should be changed for a better algo
+            // "token" should be with length 1 only for this case.
+            // See if assertion is required
+            if (char == SExprStart) {
+                const list = self.read_list() catch |err| switch (err) {
+                    Error.UnmatchedSExpr => {
+                        logz.err()
+                            .fmt("[LOG]", "statement missed matched parenthesis", .{})
+                            .log();
+
+                        mal = .Incompleted;
+                        break;
+                    },
+                    else => {
+                        @panic("Unexpected error");
+                    },
+                };
+                mal = MalType{
+                    .list = list,
+                };
+            } else if (char == SExprEnd) {
+                mal = .SExprEnd;
+            } else {
+                mal = self.read_atom(token);
+            }
+            break;
+        }
+
+        logz.info()
+            .fmt("[LOG]", "read_form result: {any}", .{mal})
+            .log();
+
+        return mal;
+    }
+
+    // As the list is not expected to be expanded, return slice instead
+    // of array list.
+    pub fn read_list(self: *Reader) !ArrayList(MalType) {
+        var list = self.createList();
+        errdefer {
+            list.deinit();
+        }
+
+        var end = false;
+        while (self.next()) |_| {
+            const malType = self.read_form();
+
+            // NOTE: append action could mutate the original object as it access
+            // the pointer and expand memory.
+            switch (malType) {
+                .SExprEnd => {
+                    end = true;
+                    break;
+                },
+                else => {
+                    try list.append(malType);
+                },
+            }
+        } else |err| {
+            switch (err) {
+                // TODO: Need to handle, see if log or throw it out
+                Error.Overflow => {},
+                // Expected case
+                Error.EOF => {},
+                else => {},
+            }
+        }
+
+        if (!end) {
+            return Error.UnmatchedSExpr;
+        }
+
+        // NOTE: Free the memory later to avoid memory leakage
+        return list;
+    }
+
+    pub fn read_atom(self: *Reader, token: Token) MalType {
+        _ = self;
+        // TODO: keyword could be dynamic
+        var isNumber = true;
+        for (token) |char| {
+            if (!isDigit(char)) {
+                isNumber = false;
+                break;
+            }
+        }
+        var mal: MalType = undefined;
+
+        // NOTE: Decide the return MalType based on different rules
+        // Like keyword case (e.g. if)
+        if (isNumber) {
+            mal = MalType{
+                .number = .{
+                    .value = utils.parseU64(token, 10) catch @panic("Unexpected overflow."),
+                },
+            };
+        } else {
+            mal = MalType{
+                .string = token,
+            };
+        }
+
+        return mal;
+    }
+};
+
+test "Reader" {
+    const allocator = std.testing.allocator;
+
+    // Simple cases
+    {
+        var r1 = Reader.init(allocator, "1");
+        defer r1.deinit();
+        debug.assert(r1.ast_root == .number);
+
+        var r2 = Reader.init(allocator, "test");
+        defer r2.deinit();
+        debug.assert(r2.ast_root == .string);
+
+        // var r3 = Reader.init(allocator, "true");
+        // defer r3.deinit();
+        // debug.assert(r3.ast_root == .boolean);
+    }
+
+    // Simple list cases
+    {
+        var l1 = Reader.init(allocator, "(\"test\")");
+        defer l1.deinit();
+        debug.assert(l1.ast_root == .list);
+        switch (l1.ast_root) {
+            .list => |list| {
+                debug.assert(list.items[0] == .string);
+                switch (list.items[0]) {
+                    .string => |str| {
+                        debug.assert(mem.eql(u8, str, "\"test\""));
+                    },
+                    else => unreachable,
+                }
+            },
+            else => unreachable,
+        }
+    }
+
+    // Multiple lists cases
+    {
+        var l2 = Reader.init(allocator, "((1) (2))");
+        defer l2.deinit();
+        debug.assert(l2.ast_root == .list);
+        switch (l2.ast_root) {
+            .list => |root_list| {
+                debug.assert(root_list.items[0] == .list);
+                switch (root_list.items[0]) {
+                    .list => |list| {
+                        switch (list.items[0]) {
+                            .number => |num| {
+                                debug.assert(num.value == 1);
+                            },
+                            else => unreachable,
+                        }
+                    },
+                    else => unreachable,
+                }
+            },
+            else => unreachable,
+        }
+    }
+
+    // Incompleted cases
+    {
+        var incompleted_list1 = Reader.init(allocator, "(1");
+        defer incompleted_list1.deinit();
+
+        debug.assert(incompleted_list1.ast_root == .Incompleted);
+    }
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const maxInt = std.math.maxInt;
 const print = std.debug.print;
 const assert = std.debug.assert;
 
@@ -16,9 +17,102 @@ pub inline fn valuesFromEnum(comptime E: type, comptime enums: type) []const E {
 }
 
 pub fn log(comptime key: []const u8, message: anytype) void {
+    // var buffer: [100]u8 = undefined;
+    // var buffer1: [100]u8 = undefined;
+    // const output_format = "{any}";
+    // const output = std.fmt.bufPrint(&buffer, "test {s}", .{output_format}) catch unreachable;
+    // const final_output = std.fmt.bufPrint(&buffer1, output, .{"aa"}) catch unreachable;
+    // std.debug.print("{s}\n", .{final_output});
+    // std.debug.print(output, .{"aa"});
+
+    // TODO: Handle the print case better
+    // The current way is due to the formatted string has to be known
+    // in comptime, which is difficult as it involves internal memory
+    // to handle string concatenation, e.g. replace "any" into "s" to
+    // handle string in formatting instead of treating them as an array
+    // of u8. Consider the print result of string "test":
+    // In {s} case: "test"
+    // In {any} case: { 116, 101, 115, 116 } <- which are ASCII codes
+    const T = @typeInfo(@TypeOf(message));
+    // std.debug.print("{any}\n", .{T});
+    switch (T) {
+        .Int => {
+            // std.debug.print("int\n", .{});
+        },
+        .Float => {
+            // std.debug.print("float\n", .{});
+        },
+        .Array => {
+            // std.debug.print("array\n", .{});
+        },
+        .Pointer => {
+            // std.debug.print("pointer\n", .{});
+            // T.Pointer.is_const == true;
+            const TT = @typeInfo(T.Pointer.child);
+            switch (TT) {
+                .Array => {
+                    if (TT.Array.child == u8) {
+                        // std.debug.print("Pointer of array type\n", .{});
+                        std.debug.print("[{s}]: {s}\n", .{ key, message });
+                        return;
+                    }
+                },
+                .Int => {
+                    std.debug.print("[{s}]: {d}\n", .{ key, message });
+                    return;
+                },
+                else => {
+                    // Uncomment the following to debug further.
+                    // std.debug.print("{any}\n", .{TT});
+                    @panic("Not implemented to handle Pointer of non-array types.");
+                },
+            }
+        },
+        else => {
+            // std.debug.print("Pending to handle\n", .{});
+        },
+    }
     std.debug.print("[{s}]: {any}\n", .{ key, message });
 }
 
 pub fn log_pointer(ptr: anytype) void {
     std.debug.print("[POINTER] {*}\n", .{ptr});
+}
+
+// From official documenation
+pub fn parseU64(buf: []const u8, radix: u8) !u64 {
+    var x: u64 = 0;
+
+    for (buf) |c| {
+        const digit = charToDigit(c);
+
+        if (digit >= radix) {
+            return error.InvalidChar;
+        }
+
+        // x *= radix
+        var ov = @mulWithOverflow(x, radix);
+        if (ov[1] != 0) return error.OverFlow;
+
+        // x += digit
+        ov = @addWithOverflow(ov[0], digit);
+        if (ov[1] != 0) return error.OverFlow;
+        x = ov[0];
+    }
+
+    return x;
+}
+
+fn charToDigit(c: u8) u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'A'...'Z' => c - 'A' + 10,
+        'a'...'z' => c - 'a' + 10,
+        else => maxInt(u8),
+    };
+}
+
+test "parse u64" {
+    const result = try parseU64("1234", 10);
+    try std.testing.expect(result == 1234);
 }


### PR DESCRIPTION
Implement Reader struct to read the statement and transform into lisp type (`MalType`), which could be considered as parsing process.

The parsing process is now based on PCRE statement to extract required tokens and process further into `MalType`.

Note the regex package is customized to support non-capturing group for now. Refer to `README.md` for related patch information.

The program shall keep reading statement and parsing into lisp type for further process, and support implementing lisp functions later.

 - feat: implement a print function(pr_str) which print from a `MalType` object
 - fix: provide `logz` setup for test case
 - update: log function prints string value as string instead of slice of bytes now.