### PR TITLE
feat: provide buffer position, cursor and frame size info in shell

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,44 @@ const ByteParsingError = error{
     EndOfStream,
 };
 
+/// Terminal escape control statement
+/// These shall be abstracted into Terminal layer later, see #12
+/// Move cursor up by {d} lines
+const TERM_MOVE_CURSOR_UP = "\x1b[{d}A";
+/// Move cursor down by {d} lines
+const TERM_MOVE_CURSOR_DOWN = "\x1b[{d}B";
+/// Move cursor right by {d} columns
+const TERM_MOVE_CURSOR_RIGHT = "\x1b[{d}C";
+/// Move cursor left by {d} columns
+const TERM_MOVE_CURSOR_LEFT = "\x1b[{d}D";
+
+/// Command to move cursor in terminal in general
+const TERM_MOVE_CURSOR = "\x1b[{d}{c}";
+
+/// Command to erase from cursor position
+const TERM_ERASE_FROM_CURSOR = "\x1b[0K";
+
+/// Command to get current cursor position
+const TERM_REQ_CURSOR_POS = "\x1b[6n";
+
+/// Max steps for the terminal to move. Used to check the frame size
+const TERM_MAX_STEPS: usize = 999;
+
+/// Available direction in two-dimension. The internal representation
+/// is for terminal movement.
+pub const Direction = enum(u8) {
+    Up = 'A',
+    Down = 'B',
+    Right = 'C',
+    Left = 'D',
+};
+
+/// Two-dimensional position representation.
+pub const Position = struct {
+    x: usize,
+    y: usize,
+};
+
 // Currently for macOS. Can this cater for other OS?
 // NOTE: How many bytes to represent an input makes sense?
 // Assume key input are in four bytes now.
@@ -98,43 +136,78 @@ fn parsing_byte(reader: std.fs.File.Reader) anyerror!keymap.InputEvent {
 // backspace function aligns both stdout and array list to store byte.
 // wrapped corresponding params into struct later.
 // TODO: For multiple bytes case it is incorrect now, like emoji input.
-fn backspace(stdout: std.fs.File, arrayList: *ArrayList(u8)) !void {
+fn backspace(stdout: std.fs.File, optional_arrayList: ?*ArrayList(u8), pos: usize) !void {
+    const charIndex = pos - 1;
+
+    // Erase the previous byte
+    if (optional_arrayList) |arrayList| {
+        _ = arrayList.*.orderedRemove(charIndex);
+    }
+
     const stdout_file = stdout.writer();
     var bw = std.io.bufferedWriter(stdout_file);
     const stdout_writer = bw.writer();
+
     // terminal display; assume to be in raw mode
     try stdout_writer.writeByte('\u{0008}');
     try stdout_writer.writeByte('\u{0020}');
     try stdout_writer.writeByte('\u{0008}');
 
-    try bw.flush();
-
-    // Erase the previous byte
-    _ = arrayList.*.pop();
-}
-
-// wrapped corresponding params into struct later.
-fn append(stdout: std.fs.File, arrayList: *ArrayList(u8), bytes: []const u8) !void {
-    const stdout_file = stdout.writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout_writer = bw.writer();
-
-    _ = try stdout_writer.write(bytes);
-    try bw.flush();
-    _ = try arrayList.*.writer().write(bytes);
-}
-
-// wrapped corresponding params into struct later.
-fn appendByte(stdout: std.fs.File, optional_arrayList: ?*ArrayList(u8), byte: u8) !void {
-    const stdout_file = stdout.writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout_writer = bw.writer();
-
-    try stdout_writer.writeByte(byte);
-    try bw.flush();
     if (optional_arrayList) |arrayList| {
-        try arrayList.*.writer().writeByte(byte);
+        var temp_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+        const allocator = temp_allocator.allocator();
+
+        // Adjustment for the string after cursor
+        const steps = arrayList.items.len - charIndex;
+        if (steps > 0) {
+            try stdout_writer.writeAll(TERM_ERASE_FROM_CURSOR);
+            try stdout_writer.writeAll(arrayList.items[charIndex..]);
+
+            const move = std.fmt.allocPrint(allocator, TERM_MOVE_CURSOR_LEFT, .{steps}) catch unreachable;
+            defer allocator.free(move);
+
+            try stdout_writer.writeAll(move);
+        }
     }
+
+    try bw.flush();
+}
+
+// wrapped corresponding params into struct later.
+fn appendByte(stdout: std.fs.File, optional_arrayList: ?*ArrayList(u8), byte: u8, pos: usize) !void {
+    if (optional_arrayList) |arrayList| {
+        try arrayList.insert(pos, byte);
+    }
+    const stdout_file = stdout.writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout_writer = bw.writer();
+
+    if (optional_arrayList) |arrayList| {
+        var temp_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+        const allocator = temp_allocator.allocator();
+
+        if (pos > 0) {
+            const move = std.fmt.allocPrint(allocator, TERM_MOVE_CURSOR_LEFT, .{pos}) catch unreachable;
+            defer allocator.free(move);
+
+            try stdout_writer.writeAll(move);
+            // Clear the line
+            try stdout_writer.writeAll(TERM_ERASE_FROM_CURSOR);
+        }
+        try stdout_writer.writeAll(arrayList.items);
+
+        // Adjust the cursor if necessary
+        const steps = arrayList.items.len - pos - 1;
+        if (steps > 0) {
+            const adjust_move = std.fmt.allocPrint(allocator, TERM_MOVE_CURSOR_LEFT, .{steps}) catch unreachable;
+            defer allocator.free(adjust_move);
+
+            try stdout_writer.writeAll(adjust_move);
+        }
+    } else {
+        try stdout_writer.writeByte(byte);
+    }
+    try bw.flush();
 }
 
 pub fn main() !void {
@@ -150,6 +223,7 @@ pub fn main() !void {
 }
 
 pub const Shell = struct {
+    allocator: std.mem.Allocator,
     stdin: std.fs.File,
     stdin_fd: *const posix.fd_t,
     orig_termios: posix.termios,
@@ -157,6 +231,14 @@ pub const Shell = struct {
 
     history: ArrayList([]u8),
     history_curr: usize,
+    /// Denotes where the buffer cursor position is at to perform append
+    /// and delete action from that point.
+    buffer_pos: usize,
+    /// Denotes the buffer cursor.
+    buffer_cursor: Position,
+
+    /// Config info about the shell
+    config: *ShellConfig,
 
     // As (logz) logger is not thread-safe, using a pool for the use
     // of the logger.
@@ -166,6 +248,13 @@ pub const Shell = struct {
     // TODO: Using a generic logger to decouple with logz if needed,
     // for example supporting log/metrics through network service?
     logger: *logz.Pool,
+
+    const ShellConfig = struct {
+        /// Denote whether the initial config is read
+        set: bool,
+        /// Denote the frame size of the shell.
+        frame_size: Position,
+    };
 
     // FIXME: enableRawMode could only be run within init now as it will
     // keeps the I/O busy s.t. the shell is struck.
@@ -187,6 +276,98 @@ pub const Shell = struct {
         const stdin_fd = self.*.stdin_fd;
         const orig_termios = self.*.orig_termios;
         try posix.tcsetattr(stdin_fd.*, .NOW, orig_termios);
+    }
+
+    /// TODO: Related to terminal part, shall be extracted to be in Terminal
+    /// struct later, see #12
+    fn term_move(self: *Shell, stdout: std.fs.File, steps: usize, direction: Direction) !void {
+        const stdout_file = stdout.writer();
+        var bw = std.io.bufferedWriter(stdout_file);
+        const stdout_writer = bw.writer();
+
+        const statement = std.fmt.allocPrint(self.allocator, TERM_MOVE_CURSOR, .{ steps, @intFromEnum(direction) }) catch unreachable;
+        defer self.allocator.free(statement);
+
+        try stdout_writer.writeAll(statement);
+
+        try bw.flush();
+    }
+
+    fn moveLeft(self: *Shell, stdout: std.fs.File) !void {
+        if (self.buffer_pos > 0) {
+            try self.term_move(stdout, 1, .Left);
+
+            self.buffer_pos -= 1;
+
+            const cursor = try self.readCursorPos(stdout);
+            self.buffer_cursor = cursor;
+        }
+    }
+
+    fn moveRight(self: *Shell, stdout: std.fs.File, buffer: ArrayList(u8)) !void {
+        if (self.buffer_pos < buffer.items.len) {
+            const prevCursor = try self.readCursorPos(stdout);
+
+            if (prevCursor.x == self.config.frame_size.x) {
+                // Handle the case when cursor is at the end of window
+                try self.term_move(stdout, prevCursor.x - 1, .Left);
+                try self.term_move(stdout, 1, .Down);
+            } else {
+                try self.term_move(stdout, 1, .Right);
+            }
+
+            self.buffer_pos += 1;
+
+            const cursor = try self.readCursorPos(stdout);
+            self.buffer_cursor = cursor;
+        }
+    }
+
+    /// Get the current frame (window in modern term) size.
+    /// In later stage when resize action is detected it should also be
+    /// called to refresh the information back to the Shell.
+    /// Reference: https://viewsourcecode.org/snaptoken/kilo/03.rawInputAndOutput.html#window-size-the-hard-way
+    fn getFrameSize(self: *Shell, stdout: std.fs.File) !Position {
+        const originalPosition = try self.readCursorPos(stdout);
+        // NOTE: Shortcut for now.
+        // Probably not updating the buffer cursor here if there are multiple
+        // windows implemented.
+        self.buffer_cursor = originalPosition;
+
+        try self.term_move(stdout, TERM_MAX_STEPS, .Right);
+        try self.term_move(stdout, TERM_MAX_STEPS, .Down);
+
+        const frameSize = try self.readCursorPos(stdout);
+
+        try self.term_move(stdout, frameSize.x - originalPosition.x, .Left);
+        try self.term_move(stdout, frameSize.y - originalPosition.y, .Up);
+
+        return frameSize;
+    }
+
+    fn readCursorPos(self: *Shell, stdout: std.fs.File) !Position {
+        const reader = self.*.stdin.reader();
+
+        const stdout_file = stdout.writer();
+        var bw = std.io.bufferedWriter(stdout_file);
+        const stdout_writer = bw.writer();
+
+        try stdout_writer.writeAll(TERM_REQ_CURSOR_POS);
+
+        try bw.flush();
+
+        // Reference for delimiter: https://vt100.net/docs/vt100-ug/chapter3.html#CPR
+        _ = try reader.readBytesNoEof(2);
+        const row_str = reader.readUntilDelimiterAlloc(self.allocator, 59, 8) catch unreachable;
+        const column_str = reader.readUntilDelimiterAlloc(self.allocator, 'R', 8) catch unreachable;
+
+        const row = utils.parseU64(row_str, 10) catch @panic("Unexpected non number value");
+        const column = utils.parseU64(column_str, 10) catch @panic("Unexpected non number value");
+
+        return Position{
+            .x = column,
+            .y = row,
+        };
     }
 
     pub fn init(allocator: std.mem.Allocator) *Shell {
@@ -215,8 +396,18 @@ pub const Shell = struct {
         //     historyArrayList.deinit();
         // }
 
+        const config = allocator.create(ShellConfig) catch @panic("OOM");
+        config.* = ShellConfig{
+            .set = false,
+            .frame_size = Position{
+                .x = 0,
+                .y = 0,
+            },
+        };
+
         const self = allocator.create(Shell) catch @panic("OOM");
         self.* = Shell{
+            .allocator = allocator,
             .stdin = stdin,
             .stdin_fd = &stdin_fd,
             .orig_termios = orig_termios,
@@ -224,13 +415,46 @@ pub const Shell = struct {
             .history = historyArrayList,
             .history_curr = 0,
             .logger = logger,
+            .buffer_pos = 0,
+            .buffer_cursor = Position{
+                .x = 0,
+                .y = 0,
+            },
+            .config = config,
         };
 
         try self.enableRawMode();
+
+        self.initConfig();
+
+        self.logConfig();
+
         return self;
     }
 
+    /// Log config info
+    fn logConfig(self: *Shell) void {
+        self.logger.logger()
+            .fmt("[LOG]", "Config info: {any}", .{self.config})
+            .level(.Debug)
+            .log();
+    }
+
+    fn initConfig(self: *Shell) void {
+        if (self.config.set) {
+            @panic("Initial config is set already. Unexpect to set again.");
+        }
+        self.config.set = true;
+
+        const stdout = std.io.getStdOut();
+        const frameSize = self.getFrameSize(stdout) catch unreachable;
+        self.config.frame_size = frameSize;
+    }
+
     fn deinit(self: *Shell) void {
+        // NOTE: Intel macOS does not require free the config memory.
+        // Align the behaviour later.
+        self.allocator.destroy(self.config);
         self.*.disableRawMode() catch @panic("deinit failed");
     }
 
@@ -290,15 +514,18 @@ pub const Shell = struct {
                                 continue;
                             }
 
-                            try backspace(stdout, &arrayList);
+                            try backspace(stdout, &arrayList, self.buffer_pos);
+                            if (self.buffer_pos > 0) {
+                                self.buffer_pos -= 1;
+                            }
                         } else if (inputEvent.ctrl and key == .J) {
                             const statement = try arrayList.toOwnedSlice();
 
                             // TODO: Shift-RET case is not handled yet. It returns same byte
                             // as only RET case, which needs to refer to io part.
                             // NOTE: Need to handle \n byte better
-                            try appendByte(stdout, &arrayList, '\n');
-                            try backspace(stdout, &arrayList);
+                            try appendByte(stdout, null, '\n', self.buffer_pos);
+                            try backspace(stdout, null, self.buffer_pos);
                             reading = false;
 
                             if (statement.len == 0) {
@@ -310,6 +537,8 @@ pub const Shell = struct {
                             try self.*.history.append(statement);
                             // Reset history
                             self.*.history_curr = self.*.history.items.len - 1;
+                            // Reset cursor
+                            self.buffer_pos = 0;
 
                             continue;
                         } else if (inputEvent.alt) {
@@ -335,9 +564,11 @@ pub const Shell = struct {
                                     }
                                 }
 
+                                self.buffer_pos = 0;
                                 const result = self.*.getHistoryItem(self.*.history_curr);
                                 for (result) |byte| {
-                                    try appendByte(stdout, &arrayList, byte);
+                                    try appendByte(stdout, &arrayList, byte, self.buffer_pos);
+                                    self.buffer_pos += 1;
                                 }
 
                                 // Set to the previous one
@@ -353,15 +584,28 @@ pub const Shell = struct {
                             }
                             const bytes = inputEvent.raw;
                             for (bytes) |byte| {
-                                try appendByte(stdout, &arrayList, byte);
+                                try appendByte(stdout, &arrayList, byte, self.buffer_pos);
+                                self.buffer_pos += 1;
                             }
                         }
                     },
-                    .functional => continue,
+                    .functional => |key| {
+                        // NOTE: Restrict for left and right only. No function
+                        // yet on buffer.
+                        if (key == .ArrowLeft) {
+                            try self.moveLeft(stdout);
+                        } else if (key == .ArrowRight) {
+                            try self.moveRight(stdout, arrayList);
+                        }
+                    },
                 }
             } else |err| switch (err) {
                 else => |e| return e,
             }
+
+            logz.debug()
+                .fmt("[CURSOR]", "length: {d}", .{self.buffer_pos})
+                .log();
         }
 
         return arrayList.toOwnedSlice();
@@ -371,10 +615,12 @@ pub const Shell = struct {
         return self.history.items[index];
     }
 
-    fn clearLine(self: Shell, stdout: std.fs.File, arrayList: *ArrayList(u8)) !void {
-        _ = self;
+    fn clearLine(self: *Shell, stdout: std.fs.File, arrayList: *ArrayList(u8)) !void {
+        // TODO: Provide efficient way for this one
         for (0..arrayList.items.len) |_| {
-            try backspace(stdout, arrayList);
+            try backspace(stdout, arrayList, self.buffer_pos);
+
+            self.buffer_pos -= 1;
         }
     }
 


### PR DESCRIPTION
Add `Position` struct to denote the x/y index value. Add `ShellConfig` struct in the shell to store the shell config. The config stores the cursor and frame size information now.

 - Provide function to move cursor left and right
 - As cursor is implemented, append and erase character in the middle of string is supported now. Change the implementation of those function to modify the array list(buffer) result first and adjust the cursor accordingly.

`buffer_pos`: Number field to denote the cursor position of the buffer
`buffer_cursor`: Position field to denote the current cursor position
`frame_size`: Position field to denote the size of frame

Resolve: #11