### PR TITLE
refactor: replace assert by testing expect in test cases

### DIFF
--- a/src/keymap_macos.zig
+++ b/src/keymap_macos.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const assert = std.debug.assert;
 
 const constants = @import("constants.zig");
 const u8_MAX = constants.u8_MAX;
@@ -530,67 +529,90 @@ pub fn mapByteToKeyCode(byte: [4]u8) KeyError!KeyCode {
     };
 }
 
+const testing = std.testing;
+
 test "InputEvent" {
     const inputEventKeyA = InputEvent.init(&u32ToBytes("\x41\xff\xff\xff"));
-    assert(inputEventKeyA.key.char == .A);
-    assert(inputEventKeyA.ctrl == false);
-    assert(inputEventKeyA.alt == false);
-    assert(inputEventKeyA.shift == true);
-    assert(std.mem.eql(u8, inputEventKeyA.raw, "\x41"));
+    try testing.expectEqual(.A, inputEventKeyA.key.char);
+    try testing.expectEqual(false, inputEventKeyA.ctrl);
+    try testing.expectEqual(false, inputEventKeyA.alt);
+    try testing.expectEqual(true, inputEventKeyA.shift);
+    try testing.expectEqualStrings("\x41", inputEventKeyA.raw);
 
     const inputEventKeya = InputEvent.init(&u32ToBytes("\x61\xff\xff\xff"));
-    assert(inputEventKeya.key.char == .A);
-    assert(inputEventKeya.ctrl == false);
-    assert(inputEventKeya.alt == false);
-    assert(inputEventKeya.shift == false);
-    assert(std.mem.eql(u8, inputEventKeya.raw, "\x61"));
+    try testing.expectEqual(.A, inputEventKeya.key.char);
+    try testing.expectEqual(false, inputEventKeya.ctrl);
+    try testing.expectEqual(false, inputEventKeya.alt);
+    try testing.expectEqual(false, inputEventKeya.shift);
+    try testing.expectEqualStrings("\x61", inputEventKeya.raw);
 
     const inputEventKeyZ = InputEvent.init(&u32ToBytes("\x5a\xff\xff\xff"));
-    assert(inputEventKeyZ.key.char == .Z);
-    assert(inputEventKeyZ.ctrl == false);
-    assert(inputEventKeyZ.alt == false);
-    assert(inputEventKeyZ.shift == true);
-    assert(std.mem.eql(u8, inputEventKeyZ.raw, "\x5a"));
+    try testing.expectEqual(.Z, inputEventKeyZ.key.char);
+    try testing.expectEqual(false, inputEventKeyZ.ctrl);
+    try testing.expectEqual(false, inputEventKeyZ.alt);
+    try testing.expectEqual(true, inputEventKeyZ.shift);
+    try testing.expectEqualStrings("\x5a", inputEventKeyZ.raw);
 
     const inputEventEof = InputEvent.init(&u32ToBytes("\x04\xff\xff\xff"));
-    assert(inputEventEof.key.char == .D);
-    assert(inputEventEof.ctrl == true);
-    assert(inputEventEof.alt == false);
-    assert(inputEventEof.shift == false);
+    try testing.expectEqual(.D, inputEventEof.key.char);
+    try testing.expectEqual(true, inputEventEof.ctrl);
+    try testing.expectEqual(false, inputEventEof.alt);
+    try testing.expectEqual(false, inputEventEof.shift);
+    try testing.expectEqualStrings("\x04", inputEventEof.raw);
 
     const inputEventEscape = InputEvent.init(&u32ToBytes("\x1b\xff\xff\xff"));
-    assert(inputEventEscape.key.char == .Escape);
-    assert(inputEventEscape.ctrl == true);
-    assert(inputEventEscape.alt == false);
-    assert(inputEventEscape.shift == false);
+    try testing.expectEqual(.Escape, inputEventEscape.key.char);
+    try testing.expectEqual(true, inputEventEscape.ctrl);
+    try testing.expectEqual(false, inputEventEscape.alt);
+    try testing.expectEqual(false, inputEventEscape.shift);
+    try testing.expectEqualStrings("\x1b", inputEventEscape.raw);
 
     const inputEventEscapeShort = InputEvent.init(&u32ToBytes("\x1b"));
-    assert(inputEventEscapeShort.key.char == .Escape);
-    assert(std.mem.eql(u8, inputEventEscapeShort.raw, "\x1b"));
+    try testing.expectEqual(.Escape, inputEventEscapeShort.key.char);
+    try testing.expectEqual(true, inputEventEscapeShort.ctrl);
+    try testing.expectEqual(false, inputEventEscapeShort.alt);
+    try testing.expectEqual(false, inputEventEscapeShort.shift);
+    try testing.expectEqualStrings("\x1b", inputEventEscapeShort.raw);
 
     const inputEventKey0Short = InputEvent.init(&u32ToBytes("\x30"));
-    assert(inputEventKey0Short.key.char == .Key0);
-    assert(std.mem.eql(u8, inputEventKey0Short.raw, "\x30"));
+    try testing.expectEqual(.Key0, inputEventKey0Short.key.char);
+    try testing.expectEqual(false, inputEventKey0Short.ctrl);
+    try testing.expectEqual(false, inputEventKey0Short.alt);
+    try testing.expectEqual(false, inputEventKey0Short.shift);
+    try testing.expectEqualStrings("\x30", inputEventKey0Short.raw);
 
     const inputEventKey9Short = InputEvent.init(&u32ToBytes("\x39"));
-    assert(inputEventKey9Short.key.char == .Key9);
-    assert(std.mem.eql(u8, inputEventKey9Short.raw, "\x39"));
+    try testing.expectEqual(.Key9, inputEventKey9Short.key.char);
+    try testing.expectEqual(false, inputEventKey9Short.ctrl);
+    try testing.expectEqual(false, inputEventKey9Short.alt);
+    try testing.expectEqual(false, inputEventKey9Short.shift);
+    try testing.expectEqualStrings("\x39", inputEventKey9Short.raw);
 
     const inputEventSpace = InputEvent.init(&u32ToBytes("\x20\xff\xff\xff"));
-    assert(inputEventSpace.key.char == .Space);
-    assert(std.mem.eql(u8, inputEventSpace.raw, "\x20"));
+    try testing.expectEqual(.Space, inputEventSpace.key.char);
+    try testing.expectEqual(false, inputEventSpace.ctrl);
+    try testing.expectEqual(false, inputEventSpace.alt);
+    try testing.expectEqual(false, inputEventSpace.shift);
+    try testing.expectEqualStrings("\x20", inputEventSpace.raw);
 
     const inputEventBackspaceShort = InputEvent.init(&u32ToBytes("\x7f"));
-    assert(inputEventBackspaceShort.key.char == .Backspace);
-    assert(std.mem.eql(u8, inputEventBackspaceShort.raw, "\x7f"));
+    try testing.expectEqual(.Backspace, inputEventBackspaceShort.key.char);
+    try testing.expectEqual(false, inputEventBackspaceShort.ctrl);
+    try testing.expectEqual(false, inputEventBackspaceShort.alt);
+    try testing.expectEqual(false, inputEventBackspaceShort.shift);
+    try testing.expectEqualStrings("\x7f", inputEventBackspaceShort.raw);
 
     const inputEventMetaN = InputEvent.init(&u32ToBytes("\x1b\x6e\xff\xff"));
-    assert(inputEventMetaN.ctrl == false);
-    assert(inputEventMetaN.alt == true);
+    try testing.expectEqual(.N, inputEventMetaN.key.char);
+    try testing.expectEqual(false, inputEventMetaN.ctrl);
+    try testing.expectEqual(true, inputEventMetaN.alt);
+    try testing.expectEqual(false, inputEventMetaN.shift);
+    try testing.expectEqualStrings("\x1b\x6e", inputEventMetaN.raw);
 
     const inputEventArrowUp = InputEvent.init(&u32ToBytes("\x1b\x5b\x41\xff"));
-    assert(inputEventArrowUp.ctrl == false);
-    assert(inputEventArrowUp.alt == false);
-    assert(inputEventArrowUp.key.functional == .ArrowUp);
-    assert(std.mem.eql(u8, inputEventArrowUp.raw, "\x1b\x5b\x41"));
+    try testing.expectEqual(.ArrowUp, inputEventArrowUp.key.functional);
+    try testing.expectEqual(false, inputEventArrowUp.ctrl);
+    try testing.expectEqual(false, inputEventArrowUp.alt);
+    try testing.expectEqual(false, inputEventArrowUp.shift);
+    try testing.expectEqualStrings("\x1b\x5b\x41", inputEventArrowUp.raw);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const assert = std.debug.assert;
 
 const logz = @import("logz");
 

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -77,6 +77,8 @@ fn initStringArrayList(allocator: mem.Allocator, str: []const u8) ArrayList(u8) 
     return al;
 }
 
+const testing = std.testing;
+
 test "printer" {
     const allocator = std.testing.allocator;
 
@@ -85,12 +87,12 @@ test "printer" {
         const bool_true = MalType{ .boolean = true };
 
         const bool_true_result = pr_str(bool_true, true);
-        debug.assert(mem.eql(u8, bool_true_result, "t"));
+        try testing.expectEqualStrings("t", bool_true_result);
 
         const bool_false = MalType{ .boolean = false };
 
         const bool_false_result = pr_str(bool_false, true);
-        debug.assert(mem.eql(u8, bool_false_result, "nil"));
+        try testing.expectEqualStrings("nil", bool_false_result);
     }
 
     // Test for string case
@@ -101,9 +103,9 @@ test "printer" {
         const str1 = MalType{ .string = str1_al };
 
         const str1_readably_result = pr_str(str1, true);
-        debug.assert(mem.eql(u8, str1_readably_result, "\"test\""));
+        try testing.expectEqualStrings("\"test\"", str1_readably_result);
         const str1_non_readably_result = pr_str(str1, false);
-        debug.assert(mem.eql(u8, str1_non_readably_result, "\"test\""));
+        try testing.expectEqualStrings("\"test\"", str1_non_readably_result);
 
         const str2_al = initStringArrayList(allocator, "te\"st");
         defer str2_al.deinit();
@@ -113,9 +115,9 @@ test "printer" {
         // stored value: "te"st"
         // readably result: "te\"st" (escaped doublequote inside)
         const str2_readably_result = pr_str(str2, true);
-        debug.assert(mem.eql(u8, str2_readably_result, "\"te\\\"st\""));
+        try testing.expectEqualStrings("\"te\\\"st\"", str2_readably_result);
         const str2_non_readably_result = pr_str(str2, false);
-        debug.assert(mem.eql(u8, str2_non_readably_result, "\"te\"st\""));
+        try testing.expectEqualStrings("\"te\"st\"", str2_non_readably_result);
 
         const str3_al = initStringArrayList(allocator, "\\");
         defer str3_al.deinit();
@@ -125,9 +127,9 @@ test "printer" {
         // stored value: "\"
         // readably result: "\\" (escaped backslash inside)
         const str3_readably_result = pr_str(str3, true);
-        debug.assert(mem.eql(u8, str3_readably_result, "\"\\\\\""));
+        try testing.expectEqualStrings("\"\\\\\"", str3_readably_result);
         const str3_non_readably_result = pr_str(str3, false);
-        debug.assert(mem.eql(u8, str3_non_readably_result, "\"\\\""));
+        try testing.expectEqualStrings("\"\\\"", str3_non_readably_result);
 
         const str4_al = initStringArrayList(allocator, "te\\\"st");
         defer str4_al.deinit();
@@ -137,9 +139,9 @@ test "printer" {
         // stored value: "te\"st"
         // readably result: "te\\\"st" (escaped backslash and doublequote inside)
         const str4_readably_result = pr_str(str4, true);
-        debug.assert(mem.eql(u8, str4_readably_result, "\"te\\\\\\\"st\""));
+        try testing.expectEqualStrings("\"te\\\\\\\"st\"", str4_readably_result);
         const str4_non_readably_result = pr_str(str4, false);
-        debug.assert(mem.eql(u8, str4_non_readably_result, "\"te\\\"st\""));
+        try testing.expectEqualStrings("\"te\\\"st\"", str4_non_readably_result);
     }
 
     // Test for list case
@@ -159,6 +161,6 @@ test "printer" {
         const list1 = MalType{ .list = list1_al };
         const list1_result = pr_str(list1, true);
 
-        debug.assert(mem.eql(u8, list1_result, "(\"1\" \"2\")"));
+        try testing.expectEqualStrings("(\"1\" \"2\")", list1_result);
     }
 }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -364,6 +364,8 @@ pub const Reader = struct {
     }
 };
 
+const testing = std.testing;
+
 test "Reader" {
     const allocator = std.testing.allocator;
 
@@ -372,7 +374,7 @@ test "Reader" {
         var sym1 = Reader.init(allocator, "test");
         defer sym1.deinit();
 
-        debug.assert(sym1.ast_root == .symbol);
+        try testing.expect(sym1.ast_root == .symbol);
     }
 
     // Boolean cases
@@ -380,23 +382,23 @@ test "Reader" {
         var b1 = Reader.init(allocator, "t");
         defer b1.deinit();
 
-        debug.assert(b1.ast_root == .boolean);
+        try testing.expect(b1.ast_root == .boolean);
         const boolean1 = b1.ast_root.as_boolean() catch unreachable;
-        debug.assert(boolean1 == true);
+        try testing.expectEqual(true, boolean1);
 
         var b2 = Reader.init(allocator, "nil");
         defer b2.deinit();
 
-        debug.assert(b2.ast_root == .boolean);
+        try testing.expect(b2.ast_root == .boolean);
         const boolean2 = b2.ast_root.as_boolean() catch unreachable;
-        debug.assert(boolean2 == false);
+        try testing.expectEqual(false, boolean2);
     }
 
     // Number cases
     {
         var n1 = Reader.init(allocator, "1");
         defer n1.deinit();
-        debug.assert(n1.ast_root == .number);
+        try testing.expect(n1.ast_root == .number);
     }
 
     // String cases
@@ -404,25 +406,25 @@ test "Reader" {
         var str1 = Reader.init(allocator, "\"test\"");
         defer str1.deinit();
 
-        debug.assert(str1.ast_root == .string);
+        try testing.expect(str1.ast_root == .string);
         const string1 = str1.ast_root.as_string() catch unreachable;
-        debug.assert(mem.eql(u8, string1.items, "test"));
+        try testing.expectEqualStrings("test", string1.items);
 
         // Read case: "te\"st"
         // Stored result: te"st
         var str2 = Reader.init(allocator, "\"te\\\"st\"");
         defer str2.deinit();
 
-        debug.assert(str2.ast_root == .string);
+        try testing.expect(str2.ast_root == .string);
         const string2 = str2.ast_root.as_string() catch unreachable;
-        debug.assert(mem.eql(u8, string2.items, "te\"st"));
+        try testing.expectEqualStrings("te\"st", string2.items);
 
         var str3 = Reader.init(allocator, "\"te\\st\"");
         defer str3.deinit();
 
-        debug.assert(str3.ast_root == .string);
+        try testing.expect(str3.ast_root == .string);
         const string3 = str3.ast_root.as_string() catch unreachable;
-        debug.assert(mem.eql(u8, string3.items, "te\\st"));
+        try testing.expectEqualStrings("te\\st", string3.items);
     }
 
     // Simple list cases
@@ -430,12 +432,12 @@ test "Reader" {
         var l1 = Reader.init(allocator, "(\"test\")");
         defer l1.deinit();
 
-        debug.assert(l1.ast_root == .list);
+        try testing.expect(l1.ast_root == .list);
 
         const list1 = l1.ast_root.as_list() catch unreachable;
-        debug.assert(list1.items[0] == .string);
+        try testing.expect(list1.items[0] == .string);
         const string1 = list1.items[0].as_string() catch unreachable;
-        debug.assert(mem.eql(u8, string1.items, "test"));
+        try testing.expectEqualStrings("test", string1.items);
     }
 
     // Multiple lists cases
@@ -443,18 +445,19 @@ test "Reader" {
         var l2 = Reader.init(allocator, "((1) (2))");
         defer l2.deinit();
 
-        debug.assert(l2.ast_root == .list);
+        try testing.expect(l2.ast_root == .list);
+
         const list2 = l2.ast_root.as_list() catch unreachable;
-        debug.assert(list2.items[0] == .list);
+        try testing.expect(list2.items[0] == .list);
         const sub_list1 = list2.items[0].as_list() catch unreachable;
-        debug.assert(sub_list1.items[0] == .number);
+        try testing.expect(sub_list1.items[0] == .number);
         const sub_list1_val = sub_list1.items[0].as_number() catch unreachable;
-        debug.assert(sub_list1_val.value == 1);
+        try testing.expectEqual(1, sub_list1_val.value);
 
         const sub_list2 = list2.items[1].as_list() catch unreachable;
-        debug.assert(sub_list2.items[0] == .number);
+        try testing.expect(sub_list2.items[0] == .number);
         const sub_list2_val = sub_list2.items[0].as_number() catch unreachable;
-        debug.assert(sub_list2_val.value == 2);
+        try testing.expectEqual(2, sub_list2_val.value);
     }
 
     // Incompleted cases
@@ -462,6 +465,6 @@ test "Reader" {
         var incompleted_list1 = Reader.init(allocator, "(1");
         defer incompleted_list1.deinit();
 
-        debug.assert(incompleted_list1.ast_root == .Incompleted);
+        try testing.expect(incompleted_list1.ast_root == .Incompleted);
     }
 }


### PR DESCRIPTION
`assert` shall be used only for runtime assertion, using expect functions from testing package could return the diff when test cases failed.