### PR TITLE
feat: implement LispEnv in lisp runtime and provide lisp functions def! and let*

### DIFF
--- a/src/env.zig
+++ b/src/env.zig
@@ -10,6 +10,48 @@ const MalType = @import("reader.zig").MalType;
 const MalTypeError = @import("reader.zig").MalTypeError;
 const LispFunction = @import("reader.zig").LispFunction;
 
+/// Pointer to the global environment, this is required as the function signature
+/// is fixed for all LispFunction. And it is require to access the environment
+/// for case like defining functions and variables.
+/// There is no guarantee such pointer exists anyway, but the program
+/// shall be inited with the LispEnv before accessing any lisp functions.
+/// NOTE: Check src/lisp.h#L578 for Lisp_Object in Emacs
+/// REVIEW below
+/// NOTE: In original Emacs case there is a global pointer which counts for all
+/// lisp symbols in runtime.
+pub var global_env_ptr: *const anyopaque = undefined;
+
+pub const SPECIAL_EVAL_TABLE = std.StaticStringMap(LispFunction).initComptime(.{
+    // According to MAL, not in Emacs env
+    .{ "def!", &set },
+});
+
+fn set(params: []MalType) MalTypeError!MalType {
+    // TODO: Access to current env
+    const env: *LispEnv = @constCast(@ptrCast(@alignCast(global_env_ptr)));
+
+    const key = try params[0].as_symbol();
+    const value = env.apply(params[1]) catch |err| switch (err) {
+        error.IllegalType => return MalTypeError.IllegalType,
+        error.Unhandled => return MalTypeError.Unhandled,
+    };
+
+    env.addVar(key, value) catch |err| switch (err) {
+        error.OutOfMemory => return MalTypeError.IllegalType,
+    };
+
+    return value;
+}
+
+fn get(params: []MalType) MalTypeError!MalType {
+    // TODO: Access to current env
+    const env: *LispEnv = @constCast(@ptrCast(@alignCast(global_env_ptr)));
+
+    const key = try params[0].as_symbol();
+
+    return env.getVar(key);
+}
+
 pub const LispEnv = struct {
     allocator: std.mem.Allocator,
     data: std.StringHashMap(MalType),
@@ -40,6 +82,7 @@ pub const LispEnv = struct {
         // initial function table.
         const baseFnTable = @constCast(&std.StringHashMap(LispFunction).init(allocator));
         readFromStaticMap(baseFnTable, data.EVAL_TABLE);
+        readFromStaticMap(baseFnTable, SPECIAL_EVAL_TABLE);
 
         const externalFnTable = std.StringHashMap(LispFunction).init(allocator);
 
@@ -52,6 +95,8 @@ pub const LispEnv = struct {
 
         self.logFnTable();
 
+        global_env_ptr = self;
+
         return self;
     }
 
@@ -59,7 +104,7 @@ pub const LispEnv = struct {
         var internalFnTableIter = self.internalFnTable.keyIterator();
         while (internalFnTableIter.next()) |key| {
             logz.info()
-                .fmt("[LISP_ENV]", "internalFnTable fn: '{s}' set", .{key.*})
+                .fmt("[LISP_ENV]", "internalFnTable fn: '{s}' set.", .{key.*})
                 .level(.Debug)
                 .log();
         }
@@ -67,7 +112,7 @@ pub const LispEnv = struct {
         var externalFnTableIter = self.externalFnTable.keyIterator();
         while (externalFnTableIter.next()) |key| {
             logz.info()
-                .fmt("[LISP_ENV]", "externalFnTable fn: '{s}' set", .{key.*})
+                .fmt("[LISP_ENV]", "externalFnTable fn: '{s}' set.", .{key.*})
                 .level(.Debug)
                 .log();
         }
@@ -77,8 +122,57 @@ pub const LispEnv = struct {
         try self.externalFnTable.put(key, value);
     }
 
-    /// apply function execute the function when the Lisp Object is in list
-    /// type and the first item is in symbol.
+    pub fn addVar(self: *Self, key: []const u8, value: MalType) !void {
+        try self.data.put(key, value);
+    }
+
+    pub fn getVar(self: *Self, key: []const u8) !MalType {
+        const optional_value = self.data.get(key);
+
+        if (optional_value) |value| {
+            return value;
+        } else {
+            // TODO: Shall return error signal
+            return MalType{ .boolean = false };
+        }
+    }
+
+    pub fn removeVar(self: *Self, key: []const u8) void {
+        const success = try self.data.remove(key);
+        if (success) {
+            logz.info()
+                .fmt("[LISP_ENV]", "var: '{s}' is removed.", .{key})
+                .level(.Debug)
+                .log();
+        } else {
+            logz.info()
+                .fmt("[LISP_ENV]", "var: '{s}' is not found.", .{key})
+                .level(.Debug)
+                .log();
+        }
+    }
+
+    /// apply function returns the Lisp object according to the type of
+    /// the object. It evals further when it is a list or symbol.
+    ///
+    /// For list, it evals in the runtime environment and return the result.
+    /// For symbol, it checks if the environment contains such value and
+    /// return accordingly.
+    pub fn apply(self: *Self, mal: MalType) !MalType {
+        switch (mal) {
+            .list => |list| {
+                return self.applyList(list);
+            },
+            .symbol => |symbol| {
+                return self.getVar(symbol);
+            },
+            else => return mal,
+        }
+    }
+
+    /// Apply function for a list, which eval the list and return the result,
+    /// it takes the first param (which should be in symbol form) as
+    /// function name and apply latter to be params.
     /// It checks if all the params on the layer needs further apply first,
     /// return the result to be the param.
     /// e.g. For (+ 1 2 (+ 2 3))
@@ -89,21 +183,19 @@ pub const LispEnv = struct {
     /// -> (+ 3 (+ 2 3))         ;; Hit (+ 1 2), call add function with accum = 1 and param = 2
     /// -> (+ 3 5)               ;; Hit the list (+2 3); Eval (+ 2 3), perhaps in new thread?
     /// -> 8
-    pub fn apply(self: *Self, mal: MalType) !MalType {
+    fn applyList(self: *Self, list: ArrayList(MalType)) MalTypeError!MalType {
         var fnName: []const u8 = undefined;
         var mal_param: MalType = undefined;
         var gpa = std.heap.GeneralPurposeAllocator(.{}){};
         const allocator = gpa.allocator();
 
         var params = ArrayList(MalType).init(allocator);
-
         defer {
             params.deinit();
             const check = gpa.deinit();
             std.debug.assert(check == .ok);
         }
 
-        const list = try mal.as_list();
         for (list.items, 0..) |_mal, i| {
             if (i == 0) {
                 fnName = _mal.as_symbol() catch |err| switch (err) {
@@ -119,18 +211,44 @@ pub const LispEnv = struct {
                 continue;
             }
 
-            if (_mal.as_list()) |_| {
-                // TODO: Need more assertion
-                // Assume the return type fits with the function
-                mal_param = try self.apply(_mal);
-                if (mal_param == .Incompleted) {
-                    return MalTypeError.IllegalType;
+            // TODO: Simple, lazy and hacky way for checking "special" form
+            if (SPECIAL_EVAL_TABLE.has(fnName)) {
+                switch (_mal) {
+                    .list => {
+                        // TODO: Need more assertion
+                        // Assume the return type fits with the function
+                        mal_param = try self.apply(_mal);
+                        if (mal_param == .Incompleted) {
+                            return MalTypeError.IllegalType;
+                        }
+                    },
+                    else => {
+                        mal_param = _mal;
+                    },
                 }
-            } else |_| {
-                mal_param = _mal;
+            } else {
+                switch (_mal) {
+                    .list, .symbol => {
+                        // TODO: Need more assertion
+                        // Assume the return type fits with the function
+                        mal_param = try self.apply(_mal);
+                        if (mal_param == .Incompleted) {
+                            return MalTypeError.IllegalType;
+                        }
+                    },
+                    else => {
+                        mal_param = _mal;
+                    },
+                }
             }
-            try params.append(mal_param);
+
+            params.append(mal_param) catch |err| switch (err) {
+                // TODO: Meaningful error for such case
+                error.OutOfMemory => return MalTypeError.Unhandled,
+            };
         }
+
+        // NOTE: Shall use the internal one instead? Though no big difference now
         if (self.internalFnTable.get(fnName)) |func| {
             const fnValue: MalType = try @call(.auto, func, .{params.items});
             return fnValue;

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,0 +1,180 @@
+const std = @import("std");
+const logz = @import("logz");
+
+const ArrayList = std.ArrayList;
+
+const data = @import("data.zig");
+const utils = @import("utils.zig");
+
+const MalType = @import("reader.zig").MalType;
+const MalTypeError = @import("reader.zig").MalTypeError;
+const LispFunction = @import("reader.zig").LispFunction;
+
+pub const LispEnv = struct {
+    allocator: std.mem.Allocator,
+    data: std.StringHashMap(MalType),
+    internalFnTable: std.StringHashMap(LispFunction),
+    externalFnTable: std.StringHashMap(LispFunction),
+
+    const Self = @This();
+
+    fn readFromStaticMap(baseTable: *std.StringHashMap(LispFunction), map: std.StaticStringMap(LispFunction)) void {
+        for (map.keys()) |key| {
+            const func = map.get(key);
+            baseTable.put(key, func.?) catch @panic("Unexpected error when putting KV pair from static map to env map");
+        }
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.data.deinit();
+        self.externalFnTable.deinit();
+        self.internalFnTable.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn init(allocator: std.mem.Allocator) *Self {
+        const self = allocator.create(Self) catch @panic("OOM");
+
+        const envData = std.StringHashMap(MalType).init(allocator);
+        // Expected to modify the pointer through function to setup
+        // initial function table.
+        const baseFnTable = @constCast(&std.StringHashMap(LispFunction).init(allocator));
+        readFromStaticMap(baseFnTable, data.EVAL_TABLE);
+
+        const externalFnTable = std.StringHashMap(LispFunction).init(allocator);
+
+        self.* = Self{
+            .allocator = allocator,
+            .data = envData,
+            .internalFnTable = baseFnTable.*,
+            .externalFnTable = externalFnTable,
+        };
+
+        self.logFnTable();
+
+        return self;
+    }
+
+    fn logFnTable(self: *Self) void {
+        var internalFnTableIter = self.internalFnTable.keyIterator();
+        while (internalFnTableIter.next()) |key| {
+            logz.info()
+                .fmt("[LISP_ENV]", "internalFnTable fn: '{s}' set", .{key.*})
+                .level(.Debug)
+                .log();
+        }
+
+        var externalFnTableIter = self.externalFnTable.keyIterator();
+        while (externalFnTableIter.next()) |key| {
+            logz.info()
+                .fmt("[LISP_ENV]", "externalFnTable fn: '{s}' set", .{key.*})
+                .level(.Debug)
+                .log();
+        }
+    }
+
+    pub fn addFn(self: *Self, key: []const u8, value: LispFunction) !void {
+        try self.externalFnTable.put(key, value);
+    }
+
+    /// apply function execute the function when the Lisp Object is in list
+    /// type and the first item is in symbol.
+    /// It checks if all the params on the layer needs further apply first,
+    /// return the result to be the param.
+    /// e.g. For (+ 1 2 (+ 2 3))
+    /// -> (+ 1 2 5) ;; Eval (+ 2 3) in recursion
+    /// -> 8
+    /// TODO: Consider if continuous apply is suitable, possible and more scalable
+    /// e.g. For (+ 1 2 (+ 2 3))
+    /// -> (+ 3 (+ 2 3))         ;; Hit (+ 1 2), call add function with accum = 1 and param = 2
+    /// -> (+ 3 5)               ;; Hit the list (+2 3); Eval (+ 2 3), perhaps in new thread?
+    /// -> 8
+    pub fn apply(self: *Self, mal: MalType) !MalType {
+        var fnName: []const u8 = undefined;
+        var mal_param: MalType = undefined;
+        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        const allocator = gpa.allocator();
+
+        var params = ArrayList(MalType).init(allocator);
+
+        defer {
+            params.deinit();
+            const check = gpa.deinit();
+            std.debug.assert(check == .ok);
+        }
+
+        const list = try mal.as_list();
+        for (list.items, 0..) |_mal, i| {
+            if (i == 0) {
+                fnName = _mal.as_symbol() catch |err| switch (err) {
+                    MalTypeError.IllegalType => {
+                        utils.log("ERROR", "Invalid symbol type to apply");
+                        return err;
+                    },
+                    else => {
+                        utils.log("ERROR", "Unhandled error");
+                        return err;
+                    },
+                };
+                continue;
+            }
+
+            if (_mal.as_list()) |_| {
+                // TODO: Need more assertion
+                // Assume the return type fits with the function
+                mal_param = try self.apply(_mal);
+                if (mal_param == .Incompleted) {
+                    return MalTypeError.IllegalType;
+                }
+            } else |_| {
+                mal_param = _mal;
+            }
+            try params.append(mal_param);
+        }
+        if (self.internalFnTable.get(fnName)) |func| {
+            const fnValue: MalType = try @call(.auto, func, .{params.items});
+            return fnValue;
+        } else {
+            utils.log("SYMBOL", "Not implemented");
+        }
+
+        return .Incompleted;
+    }
+};
+
+const testing = std.testing;
+
+test "env" {
+    const allocator = std.testing.allocator;
+
+    var mal_list = ArrayList(MalType).init(allocator);
+    defer mal_list.deinit();
+
+    const plus = MalType{
+        .symbol = "+",
+    };
+
+    const num1 = MalType{
+        .number = .{ .value = 1 },
+    };
+    const num2 = MalType{
+        .number = .{ .value = 2 },
+    };
+
+    try mal_list.append(plus);
+    try mal_list.append(num1);
+    try mal_list.append(num2);
+
+    const plus1 = MalType{
+        .list = mal_list,
+    };
+
+    {
+        const env = LispEnv.init(allocator);
+        defer env.deinit();
+
+        const plus1_value = try env.apply(plus1);
+        const plus1_value_number = plus1_value.as_number() catch unreachable;
+        try testing.expectEqual(3, plus1_value_number.value);
+    }
+}

--- a/src/keymap_macos.zig
+++ b/src/keymap_macos.zig
@@ -56,6 +56,7 @@ pub const CharKey = enum(u8) {
     // TODO: How to handle characters with shift? Should they be mapped
     // into explicit character?
     Space = 0x20,
+    ExclamationMark = 0x21,
     DoubleQuote = 0x22,
 
     Quote = 0x27,

--- a/src/main.zig
+++ b/src/main.zig
@@ -497,4 +497,26 @@ test "Shell" {
             try testing.expectEqual(MalTypeError.IllegalType, err);
         }
     }
+
+    // def case in environment
+    {
+        var def1 = Reader.init(allocator, "(def! a 1)");
+        defer def1.deinit();
+
+        try testing.expect(def1.ast_root == .list);
+
+        const def1_value = try env.apply(def1.ast_root);
+        const def1_value_number = def1_value.as_number() catch unreachable;
+        try testing.expectEqual(1, def1_value_number.value);
+
+        // def case with list eval
+        var def2 = Reader.init(allocator, "(def! a (+ 2 1))");
+        defer def2.deinit();
+
+        try testing.expect(def2.ast_root == .list);
+
+        const def2_value = try env.apply(def2.ast_root);
+        const def2_value_number = def2_value.as_number() catch unreachable;
+        try testing.expectEqual(3, def2_value_number.value);
+    }
 }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -34,7 +34,16 @@ pub const MalTypeError = error{
     IllegalType,
 };
 
+const LispEnv = @import("env.zig").LispEnv;
+
 pub const LispFunction = *const fn ([]MalType) MalTypeError!MalType;
+
+pub const LispFunctionWithEnv = *const fn ([]MalType, *LispEnv) MalTypeError!MalType;
+
+pub const GenericLispFunction = union(enum) {
+    simple: LispFunction,
+    with_env: LispFunctionWithEnv,
+};
 
 pub const Number = struct {
     // TODO: Support for floating point

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -10,7 +10,6 @@ const StringIterator = iterator.StringIterator;
 
 const ArrayList = std.ArrayList;
 const debug = std.debug;
-const mem = std.mem;
 
 const BOOLEAN_MAP = @import("semantic.zig").BOOLEAN_MAP;
 
@@ -43,71 +42,6 @@ pub const Number = struct {
 };
 
 pub const List = ArrayList(MalType);
-
-/// apply function execute the function when the Lisp Object is in list
-/// type and the first item is in symbol.
-/// It checks if all the params on the layer needs further apply first,
-/// return the result to be the param.
-/// e.g. For (+ 1 2 (+ 2 3))
-/// -> (+ 1 2 5) ;; Eval (+ 2 3) in recursion
-/// -> 8
-/// TODO: Consider if continuous apply is suitable, possible and more scalable
-/// e.g. For (+ 1 2 (+ 2 3))
-/// -> (+ 3 (+ 2 3))         ;; Hit (+ 1 2), call add function with accum = 1 and param = 2
-/// -> (+ 3 5)               ;; Hit the list (+2 3); Eval (+ 2 3), perhaps in new thread?
-/// -> 8
-pub fn apply(mal: MalType) !MalType {
-    var fnName: []const u8 = undefined;
-    var mal_param: MalType = undefined;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-
-    var params = ArrayList(MalType).init(allocator);
-
-    defer {
-        params.deinit();
-        const check = gpa.deinit();
-        std.debug.assert(check == .ok);
-    }
-
-    const list = try mal.as_list();
-    for (list.items, 0..) |_mal, i| {
-        if (i == 0) {
-            fnName = _mal.as_symbol() catch |err| switch (err) {
-                MalTypeError.IllegalType => {
-                    utils.log("ERROR", "Invalid symbol type to apply");
-                    return err;
-                },
-                else => {
-                    utils.log("ERROR", "Unhandled error");
-                    return err;
-                },
-            };
-            continue;
-        }
-
-        if (_mal.as_list()) |_| {
-            // TODO: Need more assertion
-            // Assume the return type fits with the function
-            mal_param = try apply(_mal);
-            if (mal_param == .Incompleted) {
-                return MalTypeError.IllegalType;
-            }
-        } else |_| {
-            mal_param = _mal;
-        }
-        try params.append(mal_param);
-    }
-    // TODO: Direct couple to the dependency (EVAL_TABLE) now
-    if (data.EVAL_TABLE.get(fnName)) |func| {
-        const fnValue: MalType = try @call(.auto, func, .{params.items});
-        return fnValue;
-    } else {
-        utils.log("SYMBOL", "Not implemented");
-    }
-
-    return .Incompleted;
-}
 
 pub const MalType = union(enum) {
     boolean: bool,
@@ -535,41 +469,6 @@ test "Reader" {
         try testing.expect(sub_list2.items[0] == .number);
         const sub_list2_val = sub_list2.items[0].as_number() catch unreachable;
         try testing.expectEqual(2, sub_list2_val.value);
-    }
-
-    // apply function cases
-    // NOTE: Depends on EVAL_TABLE
-    {
-        // List cases
-        var l1 = Reader.init(allocator, "(+ 1 2 3)");
-        defer l1.deinit();
-
-        try testing.expect(l1.ast_root == .list);
-
-        const l1_value = try apply(l1.ast_root);
-        const l1_value_number = l1_value.as_number() catch unreachable;
-        try testing.expectEqual(6, l1_value_number.value);
-
-        // List within list cases
-        var l2 = Reader.init(allocator, "(+ 1 (+ 2 3))");
-        defer l2.deinit();
-
-        try testing.expect(l2.ast_root == .list);
-
-        const l2_value = try apply(l2.ast_root);
-        const l2_value_number = l2_value.as_number() catch unreachable;
-        try testing.expectEqual(6, l2_value_number.value);
-
-        // Unexpected non-symbol case.
-        // TODO: This may be changed if list type for non-symbol first item is implemented.
-        var ns1 = Reader.init(allocator, "(1 2)");
-        defer ns1.deinit();
-
-        try testing.expect(ns1.ast_root == .list);
-
-        if (apply(ns1.ast_root)) |_| {} else |err| {
-            try testing.expectEqual(MalTypeError.IllegalType, err);
-        }
     }
 
     // Incompleted cases


### PR DESCRIPTION
Provides a `LispEnv` within the program to support further lisp functions, particularly `def!` and `let*`

As `def!` and `let*` requires the runtime to have the ability storing variables, it is required to have an environment for such purpose. `LispEnv` is responsible for this. It provides storage for data and functions, and they are stored by two hashmaps keyed by string separately. Internal functions are made to support get/put operations, allowing their usages in applying the lisp statement.

The `apply` function in main REPL is now relied on a global `LispEnv` which is under `Shell`.