### PR TITLE
refactor: extract lisp type out from token_reader and provide lisp hash map type

### DIFF
--- a/src/data.zig
+++ b/src/data.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
 const token_reader = @import("reader.zig");
+const lisp = @import("types/lisp.zig");
 
-const MalType = token_reader.MalType;
-const MalTypeError = token_reader.MalTypeError;
-const LispFunction = token_reader.LispFunction;
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunction = lisp.LispFunction;
 
 // TODO: Parser part
 pub const EVAL_TABLE = std.StaticStringMap(LispFunction).initComptime(.{

--- a/src/env.zig
+++ b/src/env.zig
@@ -6,11 +6,12 @@ const ArrayList = std.ArrayList;
 const data = @import("data.zig");
 const utils = @import("utils.zig");
 
-const MalType = @import("reader.zig").MalType;
-const MalTypeError = @import("reader.zig").MalTypeError;
-const LispFunction = @import("reader.zig").LispFunction;
-const LispFunctionWithEnv = @import("reader.zig").LispFunctionWithEnv;
-const GenericLispFunction = @import("reader.zig").GenericLispFunction;
+const lisp = @import("types/lisp.zig");
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunction = lisp.LispFunction;
+const LispFunctionWithEnv = lisp.LispFunctionWithEnv;
+const GenericLispFunction = lisp.GenericLispFunction;
 
 /// Pointer to the global environment, this is required as the function signature
 /// is fixed for all LispFunction. And it is require to access the environment
@@ -83,12 +84,11 @@ pub const LispEnv = struct {
     outer: ?*LispEnv,
     allocator: std.mem.Allocator,
     data: std.StringHashMap(MalType),
-    // TODO: Consider using HashMap for both MalType value
-    fnTable: std.StringHashMap(FunctionWithAttributes),
+    fnTable: lisp.MalTypeHashMap(FunctionWithAttributes),
 
     const Self = @This();
 
-    fn readFromStaticMap(baseTable: *std.StringHashMap(FunctionWithAttributes), map: std.StaticStringMap(LispFunction)) void {
+    fn readFromStaticMap(baseTable: *lisp.MalTypeHashMap(FunctionWithAttributes), map: std.StaticStringMap(LispFunction)) void {
         for (map.keys()) |key| {
             const optional_func = map.get(key);
             if (optional_func) |func| {
@@ -96,12 +96,17 @@ pub const LispEnv = struct {
                     .type = .internal,
                     .func = GenericLispFunction{ .simple = func },
                 };
-                baseTable.put(key, value) catch @panic("Unexpected error when putting KV pair from static map to env map");
+                const lispKey = baseTable.allocator.create(MalType) catch @panic("OOM");
+                lispKey.* = MalType{
+                    .symbol = key,
+                };
+
+                baseTable.put(lispKey, value) catch @panic("Unexpected error when putting KV pair from static map to env map");
             }
         }
     }
 
-    fn readFromEnvStaticMap(baseTable: *std.StringHashMap(FunctionWithAttributes), map: std.StaticStringMap(LispFunctionWithEnv)) void {
+    fn readFromEnvStaticMap(baseTable: *lisp.MalTypeHashMap(FunctionWithAttributes), map: std.StaticStringMap(LispFunctionWithEnv)) void {
         for (map.keys()) |key| {
             const optional_func = map.get(key);
             if (optional_func) |func| {
@@ -109,13 +114,22 @@ pub const LispEnv = struct {
                     .type = .internal,
                     .func = GenericLispFunction{ .with_env = func },
                 };
-                baseTable.put(key, value) catch @panic("Unexpected error when putting KV pair from static map to env map");
+                const lispKey = baseTable.allocator.create(MalType) catch @panic("OOM");
+                lispKey.* = MalType{
+                    .symbol = key,
+                };
+
+                baseTable.put(lispKey, value) catch @panic("Unexpected error when putting KV pair from static map to env map");
             }
         }
     }
 
     pub fn deinit(self: *Self) void {
         self.data.deinit();
+        var fnTableIter = self.fnTable.iterator();
+        while (fnTableIter.next()) |func| {
+            self.fnTable.allocator.destroy(func.key_ptr.*);
+        }
         self.fnTable.deinit();
         self.allocator.destroy(self);
     }
@@ -126,7 +140,7 @@ pub const LispEnv = struct {
         const envData = std.StringHashMap(MalType).init(allocator);
         // Expected to modify the pointer through function to setup
         // initial function table.
-        const fnTable = @constCast(&std.StringHashMap(FunctionWithAttributes).init(allocator));
+        const fnTable = @constCast(&lisp.MalTypeHashMap(FunctionWithAttributes).init(allocator));
         readFromStaticMap(fnTable, data.EVAL_TABLE);
         readFromEnvStaticMap(fnTable, SPECIAL_ENV_EVAL_TABLE);
 
@@ -147,8 +161,9 @@ pub const LispEnv = struct {
     fn init(allocator: std.mem.Allocator, outer: *Self) *Self {
         const self = allocator.create(Self) catch @panic("OOM");
 
-        const fnTable = std.StringHashMap(FunctionWithAttributes).init(allocator);
         const envData = std.StringHashMap(MalType).init(allocator);
+
+        const fnTable = lisp.MalTypeHashMap(FunctionWithAttributes).init(allocator);
 
         self.* = Self{
             .outer = outer,
@@ -161,26 +176,38 @@ pub const LispEnv = struct {
     }
 
     fn logFnTable(self: *Self) void {
-        var fnTableIter = self.fnTable.keyIterator();
-        while (fnTableIter.next()) |key| {
+        var newfnTableIter = self.fnTable.keyIterator();
+        while (newfnTableIter.next()) |key| {
+            const symbol = key.*.as_symbol() catch @panic("Unexpected non-symbol key value");
+
             logz.info()
-                .fmt("[LISP_ENV]", "fnTable fn: '{s}' set.", .{key.*})
+                .fmt("[LISP_ENV]", "fnTable fn: '{s}' set.", .{symbol})
                 .level(.Debug)
                 .log();
         }
     }
 
     pub fn addFn(self: *Self, key: []const u8, value: LispFunction) !void {
+        const lispKey = try self.allocator.create(MalType);
+        lispKey.* = MalType{
+            .symbol = key,
+        };
+
         const inputValue = GenericLispFunction{ .simple = value };
-        try self.fnTable.put(key, .{
+        try self.fnTable.put(lispKey, .{
             .func = inputValue,
             .type = .external,
         });
     }
 
     pub fn addFnWithEnv(self: *Self, key: []const u8, value: LispFunctionWithEnv) !void {
+        const lispKey = try self.allocator.create(MalType);
+        lispKey.* = MalType{
+            .symbol = key,
+        };
+
         const inputValue = GenericLispFunction{ .with_env = value };
-        try self.fnTable.put(key, .{
+        try self.fnTable.put(lispKey, .{
             .func = inputValue,
             .type = .external,
         });
@@ -325,7 +352,8 @@ pub const LispEnv = struct {
         var optional_env: ?*LispEnv = self;
 
         while (optional_env) |env| {
-            if (env.fnTable.get(fnName)) |funcWithAttr| {
+            var key = MalType{ .symbol = fnName };
+            if (env.fnTable.get(&key)) |funcWithAttr| {
                 const func = funcWithAttr.func;
                 var fnValue: MalType = undefined;
                 switch (func) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,11 +10,12 @@ const u8_MAX = constants.u8_MAX;
 const token_reader = @import("reader.zig");
 const printer = @import("printer.zig");
 const data = @import("data.zig");
+const lisp = @import("types/lisp.zig");
 
 const ArrayList = std.ArrayList;
 const Reader = token_reader.Reader;
-const MalType = token_reader.MalType;
-const MalTypeError = token_reader.MalTypeError;
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
 
 const LispEnv = @import("env.zig").LispEnv;
 

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -7,7 +7,7 @@ const ArrayList = std.ArrayList;
 const debug = std.debug;
 const mem = std.mem;
 
-const MalType = @import("reader.zig").MalType;
+const MalType = @import("types/lisp.zig").MalType;
 
 const semantic = @import("semantic.zig");
 

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -6,6 +6,11 @@ const data = @import("data.zig");
 const utils = @import("utils.zig");
 const iterator = @import("iterator.zig");
 
+const lisp = @import("types/lisp.zig");
+const List = lisp.List;
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+
 const StringIterator = iterator.StringIterator;
 
 const ArrayList = std.ArrayList;
@@ -29,103 +34,7 @@ fn isDigit(char: u8) bool {
     return char >= '0' and char <= '9';
 }
 
-pub const MalTypeError = error{
-    Unhandled,
-    IllegalType,
-};
-
 const LispEnv = @import("env.zig").LispEnv;
-
-pub const LispFunction = *const fn ([]MalType) MalTypeError!MalType;
-
-pub const LispFunctionWithEnv = *const fn ([]MalType, *LispEnv) MalTypeError!MalType;
-
-pub const GenericLispFunction = union(enum) {
-    simple: LispFunction,
-    with_env: LispFunctionWithEnv,
-};
-
-pub const Number = struct {
-    // TODO: Support for floating point
-    value: u64,
-};
-
-pub const List = ArrayList(MalType);
-
-pub const MalType = union(enum) {
-    boolean: bool,
-    number: Number,
-    /// An array which is ordered sequence of characters. The basic way
-    /// to create is by using double quotes.
-    string: ArrayList(u8),
-    list: List,
-    /// General symbol type including function
-    symbol: []const u8,
-
-    SExprEnd,
-    /// Incompleted type from parser
-    Incompleted,
-
-    pub fn deinit(self: MalType) void {
-        switch (self) {
-            .string => |string| {
-                string.deinit();
-            },
-            .list => |list| {
-                for (list.items) |item| {
-                    item.deinit();
-                }
-                list.deinit();
-            },
-            else => {},
-        }
-    }
-
-    pub fn as_symbol(self: MalType) MalTypeError![]const u8 {
-        switch (self) {
-            .symbol => |symbol| {
-                return symbol;
-            },
-            else => return MalTypeError.IllegalType,
-        }
-    }
-
-    pub fn as_boolean(self: MalType) MalTypeError!bool {
-        switch (self) {
-            .boolean => |boolean| {
-                return boolean;
-            },
-            else => return MalTypeError.IllegalType,
-        }
-    }
-
-    pub fn as_number(self: MalType) MalTypeError!Number {
-        switch (self) {
-            .number => |num| {
-                return num;
-            },
-            else => return MalTypeError.IllegalType,
-        }
-    }
-
-    pub fn as_string(self: MalType) MalTypeError!ArrayList(u8) {
-        switch (self) {
-            .string => |str| {
-                return str;
-            },
-            else => return MalTypeError.IllegalType,
-        }
-    }
-
-    pub fn as_list(self: MalType) MalTypeError!ArrayList(MalType) {
-        switch (self) {
-            .list => |list| {
-                return list;
-            },
-            else => return MalTypeError.IllegalType,
-        }
-    }
-};
 
 // NOTE: Currently the regex requires fix to allow repeater after pipe('|')
 // char. Check isByteClass method in the library.

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const hash_map = std.hash_map;
+
+const ArrayList = std.ArrayList;
+const HashMap = hash_map.HashMap;
+
+const LispEnv = @import("../env.zig").LispEnv;
+
+pub const LispFunction = *const fn ([]MalType) MalTypeError!MalType;
+
+pub const LispFunctionWithEnv = *const fn ([]MalType, *LispEnv) MalTypeError!MalType;
+
+pub const GenericLispFunction = union(enum) {
+    simple: LispFunction,
+    with_env: LispFunctionWithEnv,
+};
+
+pub const List = ArrayList(MalType);
+
+pub const MalTypeError = error{
+    Unhandled,
+    IllegalType,
+};
+
+pub const Number = struct {
+    // TODO: Support for floating point
+    value: u64,
+};
+
+pub const MalType = union(enum) {
+    boolean: bool,
+    number: Number,
+    /// An array which is ordered sequence of characters. The basic way
+    /// to create is by using double quotes.
+    string: ArrayList(u8),
+    list: List,
+    /// General symbol type including function
+    symbol: []const u8,
+
+    SExprEnd,
+    /// Incompleted type from parser
+    Incompleted,
+
+    pub fn deinit(self: MalType) void {
+        switch (self) {
+            .string => |string| {
+                string.deinit();
+            },
+            .list => |list| {
+                for (list.items) |item| {
+                    item.deinit();
+                }
+                list.deinit();
+            },
+            else => {},
+        }
+    }
+
+    pub fn as_symbol(self: MalType) MalTypeError![]const u8 {
+        switch (self) {
+            .symbol => |symbol| {
+                return symbol;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
+    pub fn as_boolean(self: MalType) MalTypeError!bool {
+        switch (self) {
+            .boolean => |boolean| {
+                return boolean;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
+    pub fn as_number(self: MalType) MalTypeError!Number {
+        switch (self) {
+            .number => |num| {
+                return num;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
+    pub fn as_string(self: MalType) MalTypeError!ArrayList(u8) {
+        switch (self) {
+            .string => |str| {
+                return str;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
+    pub fn as_list(self: MalType) MalTypeError!ArrayList(MalType) {
+        switch (self) {
+            .list => |list| {
+                return list;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+};
+
+const MalTypeContext = struct {
+    pub fn hash(_: @This(), key: *MalType) u64 {
+        return switch (key.*) {
+            .symbol => |s| hash_map.hashString(s),
+            .string => |str| hash_map.hashString(str.items),
+            else => unreachable,
+        };
+    }
+
+    pub fn eql(_: @This(), ma: *MalType, mb: *MalType) bool {
+        return switch (ma.*) {
+            .symbol => |a| switch (mb.*) {
+                .symbol => |b| hash_map.eqlString(a, b),
+                else => false,
+            },
+            .string => |a| switch (mb.*) {
+                .string => |b| hash_map.eqlString(a.items, b.items),
+                else => false,
+            },
+            else => unreachable,
+        };
+    }
+};
+
+pub fn MalTypeHashMap(comptime V: type) type {
+    return HashMap(*MalType, V, MalTypeContext, 80);
+}


### PR DESCRIPTION
Extract lisp type out to separate the work from `token_reader.zig`.

Provide lisp hash map type, and replace the use of string hash map for function table in lisp environment.
  - The key is owned by hash map such that key can be freed when the hash map is deinited, which fits with how zig handles init/deinit struct.