### PR TITLE
feat: Provide vector structure

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -62,7 +62,7 @@ fn parsing_statement(statement: []const u8) *token_reader.Reader {
     const str = printer.pr_str(read_result.ast_root, true);
 
     logz.info()
-        .fmt("[LOG]", "print: {any}", .{str})
+        .fmt("[LOG]", "print: \"{s}\"", .{str})
         .log();
 
     return read_result;

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -67,6 +67,17 @@ pub fn pr_str(mal: MalType, print_readably: bool) []u8 {
         .function => |_| {
             string.appendSlice("#<function>") catch @panic("allocator error");
         },
+        .vector => |vector| {
+            string.appendSlice("[") catch @panic("allocator error");
+            for (vector.items) |item| {
+                const result = pr_str(item, print_readably);
+                string.appendSlice(result) catch @panic("allocator error");
+                string.appendSlice(" ") catch @panic("allocator error");
+            }
+            // Remove the last space
+            _ = string.pop();
+            string.appendSlice("]") catch @panic("allocator error");
+        },
         else => {},
     }
 

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -46,6 +46,7 @@ pub const MalType = union(enum) {
     function: *LispEnv,
 
     SExprEnd,
+    VectorExprEnd,
     /// Incompleted type from parser
     Incompleted,
     /// Undefined param for function

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -19,6 +19,8 @@ pub const GenericLispFunction = union(enum) {
 
 pub const List = ArrayList(MalType);
 
+pub const Vector = List;
+
 pub const MalTypeError = error{
     Unhandled,
     IllegalType,
@@ -36,6 +38,8 @@ pub const MalType = union(enum) {
     /// to create is by using double quotes.
     string: ArrayList(u8),
     list: List,
+    /// Vector type, which provide constant-time element access
+    vector: Vector,
     /// General symbol type including function keyword
     symbol: []const u8,
 
@@ -57,6 +61,12 @@ pub const MalType = union(enum) {
                     item.deinit();
                 }
                 list.deinit();
+            },
+            .vector => |vector| {
+                for (vector.items) |item| {
+                    item.deinit();
+                }
+                vector.deinit();
             },
             .function => |func_with_env| {
                 func_with_env.deinit();
@@ -105,6 +115,15 @@ pub const MalType = union(enum) {
         switch (self) {
             .list => |list| {
                 return list;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
+    pub fn as_vector(self: MalType) MalTypeError!Vector {
+        switch (self) {
+            .vector => |vector| {
+                return vector;
             },
             else => return MalTypeError.IllegalType,
         }

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -294,3 +294,23 @@ test "lambda function - simple case - multiple variables" {
     const result = printer.pr_str(lambda_statement_value, true);
     try testing.expectEqualStrings("6", result);
 }
+
+test "vector function - simple case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "(vector 1 2)");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[1 2]", result);
+
+}

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -312,5 +312,59 @@ test "vector function - simple case" {
 
     const result = printer.pr_str(vector_statement_value, true);
     try testing.expectEqualStrings("[1 2]", result);
+}
 
+test "vectorp function - truthy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vectorp_statement = Reader.init(allocator, "(vectorp (vector 1 2))");
+    defer vectorp_statement.deinit();
+
+    try testing.expect(vectorp_statement.ast_root == .list);
+
+    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root);
+
+    const result = printer.pr_str(vectorp_statement_value, true);
+    try testing.expectEqualStrings("t", result);
+}
+
+test "vectorp function - falsy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vectorp_statement = Reader.init(allocator, "(vectorp nil)");
+    defer vectorp_statement.deinit();
+
+    try testing.expect(vectorp_statement.ast_root == .list);
+
+    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root);
+
+    const result = printer.pr_str(vectorp_statement_value, true);
+    try testing.expectEqualStrings("nil", result);
+}
+
+test "vectorp function - through let* to create variable case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var is_vector_var_statement = Reader.init(
+        allocator,
+        "(let* ((vector_param (vector 1 2))) (vectorp vector_param))",
+    );
+    defer is_vector_var_statement.deinit();
+
+    const is_vector_var_statement_value = try env.apply(is_vector_var_statement.ast_root);
+
+    const result = printer.pr_str(is_vector_var_statement_value, true);
+    try testing.expectEqualStrings("t", result);
+
+    const is_vector_var_statement_value_bool = is_vector_var_statement_value.as_boolean() catch unreachable;
+    try testing.expectEqual(true, is_vector_var_statement_value_bool);
 }

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -295,6 +295,25 @@ test "lambda function - simple case - multiple variables" {
     try testing.expectEqualStrings("6", result);
 }
 
+test "[] syntax to create vector - simple case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "[1 2]");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[1 2]", result);
+}
+
 test "vector function - simple case" {
     const allocator = testing.allocator;
 


### PR DESCRIPTION
Provide vector structure and related lisp function, including `vector` and `vectorp`, and allows bracket representation to create vector, and also use that in printer function.
- `vector`: Create vector in lisp environment
- `vectorp`: Check if a given object is a vector or not