### PR TITLE
feat: provide plugin feature

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,12 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.addImport("regex", regex.module("regex"));
 
+    const xev = b.dependency("libxev", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("xev", xev.module("xev"));
+
     // Provides glizp module out, which makes glizp to be used as a library.
     const glizp_module = b.addModule("glizp", .{
         .root_source_file = b.path("src/lib.zig"),
@@ -46,6 +52,7 @@ pub fn build(b: *std.Build) void {
 
     glizp_module.addImport("logz", logz.module("logz"));
     glizp_module.addImport("regex", regex.module("regex"));
+    glizp_module.addImport("xev", xev.module("xev"));
 
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
@@ -104,6 +111,7 @@ pub fn build(b: *std.Build) void {
     general_tests.root_module.addImport("glizp", glizp_module);
     general_tests.root_module.addImport("logz", logz.module("logz"));
     general_tests.root_module.addImport("regex", regex.module("regex"));
+    general_tests.root_module.addImport("xev", xev.module("xev"));
 
     const run_general_tests = b.addRunArtifact(general_tests);
 
@@ -121,6 +129,7 @@ pub fn build(b: *std.Build) void {
 
     exe_unit_tests.root_module.addImport("logz", logz.module("logz"));
     exe_unit_tests.root_module.addImport("regex", regex.module("regex"));
+    exe_unit_tests.root_module.addImport("xev", xev.module("xev"));
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
@@ -135,6 +144,7 @@ pub fn build(b: *std.Build) void {
     });
     reader_test.root_module.addImport("logz", logz.module("logz"));
     reader_test.root_module.addImport("regex", regex.module("regex"));
+    reader_test.root_module.addImport("xev", xev.module("xev"));
 
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,6 +12,10 @@
             .url = "../zig-regex",
             .hash = "1220b0c913700f12e0691d4fcf9773df8568e1a2e0b3a861282d9987bf2c834480f2",
         },
+        .libxev = .{
+            .url = "https://github.com/mitchellh/libxev/archive/94ed6af7b2aaaeab987fbf87fcee410063df715b.tar.gz",
+            .hash = "12207bbafd62d126bacad2444d9422fe51c9ac89aef662dbf66a228053722f27a0d6",
+        },
     },
     .paths = .{
         "",

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,8 @@ const LispEnv = @import("env.zig").LispEnv;
 const Frontend = @import("Frontend.zig");
 const Terminal = @import("terminal.zig").Terminal;
 
+const PluginExample = @import("plugin-example.zig").PluginExample;
+
 const INIT_CONFIG_FILE = "init.el";
 
 // NOTE: Shall be OS-dependent, to support different emoji it may require
@@ -183,6 +185,9 @@ pub const Shell = struct {
         const frontend = terminal.frontend();
 
         const env = LispEnv.init_root(allocator);
+
+        const plugin_example = PluginExample.init(allocator);
+        env.*.registerPlugin(plugin_example) catch @panic("OOM");
 
         const self = allocator.create(Shell) catch @panic("OOM");
         self.* = Shell{

--- a/src/message_queue.zig
+++ b/src/message_queue.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const xev = @import("xev");
+
+const utils = @import("utils.zig");
+
+pub const MessageQueue = struct {
+    allocator: std.mem.Allocator,
+    spsc: struct {
+        // TODO: Decide the type later
+        queue: std.ArrayList([]const u8),
+        wakeup: xev.Async align(64),
+    },
+
+    pub fn initSPSC(allocator: std.mem.Allocator) *MessageQueue {
+        var queue = std.ArrayList([]const u8).init(allocator);
+        errdefer queue.deinit();
+
+        var wakeup = xev.Async.init() catch @panic("Unexpected error");
+        errdefer wakeup.deinit();
+
+        const msgQueue = allocator.create(MessageQueue) catch @panic("OOM");
+
+        msgQueue.* = .{
+            .allocator = allocator,
+            .spsc = .{
+                .wakeup = wakeup,
+                .queue = queue,
+            },
+        };
+
+        return msgQueue;
+    }
+
+    pub fn deinit(self: *MessageQueue) void {
+        self.spsc.queue.deinit();
+        var wakeup: *xev.Async = @constCast(@alignCast(&self.spsc.wakeup));
+        wakeup.deinit();
+
+        self.allocator.destroy(self);
+    }
+
+    pub fn append(self: *MessageQueue, item: []const u8) !void {
+        try self.spsc.queue.append(item);
+    }
+
+    pub fn popOrNull(self: *MessageQueue) ?[]const u8 {
+        return self.spsc.queue.pop();
+    }
+
+    pub fn getLastOrNull(self: *MessageQueue) ?[]const u8 {
+        return self.spsc.queue.getLastOrNull();
+    }
+
+    pub fn wait(
+        self: MessageQueue,
+        loop: *xev.Loop,
+        c: *xev.Completion,
+        comptime Userdata: type,
+        userdata: ?*Userdata,
+        comptime cb: *const fn (
+            ud: ?*Userdata,
+            l: *xev.Loop,
+            c: *xev.Completion,
+            r: xev.Async.WaitError!void,
+        ) xev.CallbackAction,
+    ) void {
+        self.spsc.wakeup.wait(loop, c, Userdata, userdata, cb);
+    }
+
+    pub fn notify(self: *MessageQueue) !void {
+        var spsc = self.spsc;
+        try spsc.wakeup.notify();
+    }
+};

--- a/src/plugin-example.zig
+++ b/src/plugin-example.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const lisp = @import("types/lisp.zig");
+
+const LispEnv = @import("env.zig").LispEnv;
+const Plugin = @import("types/plugin.zig");
+const Message = @import("types/plugin.zig").Message;
+
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunction = lisp.LispFunction;
+const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
+
+const MessageQueue = @import("message_queue.zig").MessageQueue;
+
+const utils = @import("utils.zig");
+
+const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
+    .{ "get-plugin-value", &get },
+    .{ "add-plugin-value", &add },
+    .{ "set-plugin-value", &set },
+});
+
+fn get(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    _ = params;
+
+    const pluginEnv: *PluginExample = @ptrCast(@alignCast(env));
+
+    const result = MalType{ .number = .{ .value = pluginEnv.num } };
+
+    utils.log("get-plugin-value", pluginEnv.num);
+
+    return result;
+}
+
+fn add(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    _ = params;
+
+    const pluginEnv: *PluginExample = @ptrCast(@alignCast(env));
+
+    pluginEnv.num += 1;
+
+    const result = MalType{ .number = .{ .value = pluginEnv.num } };
+
+    utils.log("set-plugin-value", pluginEnv.num);
+
+    return result;
+}
+
+fn set(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    const pluginEnv: *PluginExample = @ptrCast(@alignCast(env));
+
+    const value = try params[0].as_number();
+
+    pluginEnv.num = value.value;
+
+    return params[0];
+}
+
+pub const PluginExample = struct {
+    _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
+
+    num: u64,
+
+    pub fn init(allocator: std.mem.Allocator) *PluginExample {
+        const self = allocator.create(PluginExample) catch @panic("OOM");
+
+        self.* = .{
+            .num = 1,
+            ._fnTable = EVAL_TABLE,
+        };
+
+        return self;
+    }
+
+    /// Common method for all plugin instance. Work as a hook.
+    /// This is not useful for this plugin, only serves as example.
+    pub fn subscribeEvent(self: *PluginExample, messages: *MessageQueue) !void {
+        // TODO: The subscription shall filter out correct message.
+        if (messages.getLastOrNull()) |item| {
+            utils.log("TEST", item);
+
+            utils.log("TEST", self.num);
+        }
+    }
+};

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -12,9 +12,14 @@ pub const LispFunction = *const fn ([]MalType) MalTypeError!MalType;
 
 pub const LispFunctionWithEnv = *const fn ([]MalType, *LispEnv) MalTypeError!MalType;
 
+/// For plugin purpose, the function shall allow to reference back
+/// to the plugin instance, which is denoted as *anyopaque.
+pub const LispFunctionWithOpaque = *const fn ([]MalType, *anyopaque) MalTypeError!MalType;
+
 pub const GenericLispFunction = union(enum) {
     simple: LispFunction,
     with_env: LispFunctionWithEnv,
+    plugin: LispFunctionWithOpaque,
 };
 
 pub const List = ArrayList(MalType);

--- a/src/types/plugin.zig
+++ b/src/types/plugin.zig
@@ -1,0 +1,104 @@
+//! Plugin abstractation. This supports having additional functionality
+//! in the lisp environment, which separates the core function of an
+//! interpreter and different functions to work as a shell or editor
+//! like Terminal and Emacs.
+//!
+//! The plugin holds the fields separately, and by setting the function
+//! on "fnTable", it allows to use lisp-way to access such fields within
+//! the lisp environment.
+//! Check plugin-example.zig on how Plugin is created.
+//!
+//! TODO: Naming convention for the function; What if duplicate name occurs
+const std = @import("std");
+const MalType = @import("lisp.zig").MalType;
+const LispFunctionWithOpaque = @import("lisp.zig").LispFunctionWithOpaque;
+
+const LispEnv = @import("../env.zig").LispEnv;
+const MessageQueue = @import("../message_queue.zig").MessageQueue;
+
+const utils = @import("../utils.zig");
+
+pub const Message = struct {
+    name: u8,
+};
+
+/// Pointer to the actual instance.
+context: *const anyopaque,
+/// Virtual table to store the function pointers on actual implementations.
+vtable: *const VTable,
+/// Name of the plugin.
+name: []const u8,
+/// Corresponding environment data.
+envData: *std.StringHashMap(MalType),
+/// Corresponding queue data. Used for event subscription from async handler.
+queue: *MessageQueue,
+
+/// Function table key by string.
+fnTable: ?std.StaticStringMap(LispFunctionWithOpaque),
+
+pub const VTable = struct {
+    subscribe: *const fn (context: *const anyopaque, *std.StringHashMap(MalType)) anyerror!void,
+    subscribeEvent: *const fn (context: *const anyopaque, *MessageQueue) anyerror!void,
+};
+
+pub fn subscribe(self: Self) !void {
+    try self.vtable.subscribe(self.context, self.envData);
+}
+
+pub fn subscribeEvent(self: Self) !void {
+    try self.vtable.subscribeEvent(self.context, self.queue);
+}
+
+const Self = @This();
+
+pub fn init(obj: anytype, envData: *std.StringHashMap(MalType), messages: *MessageQueue) Self {
+    const TypePtr = @TypeOf(obj);
+    const Type = @TypeOf(obj.*);
+
+    var name: []const u8 = "";
+    if (@hasField(Type, "name")) {
+        name = obj.name;
+    } else {
+        var it = std.mem.splitScalar(u8, @typeName(TypePtr), '.');
+        while (it.next()) |str| {
+            name = str;
+        }
+    }
+
+    const impl = struct {
+        // TODO: Consider generalize these functions.
+        fn subscribe(context: *const anyopaque, inner_env: *std.StringHashMap(MalType)) !void {
+            const self: TypePtr = @constCast(@ptrCast(@alignCast(context)));
+
+            const method_name = "subscribe";
+            if (@hasDecl(@TypeOf(self.*), method_name)) {
+                self.subscribe(inner_env) catch @panic("PLUGIn");
+            } else {
+                utils.log("PLUGIN", std.fmt.comptimePrint("method \"{s}\" not implemented yet", .{method_name}));
+            }
+        }
+
+        fn subscribeEvent(context: *const anyopaque, messageQueue: *MessageQueue) anyerror!void {
+            const self: TypePtr = @constCast(@ptrCast(@alignCast(context)));
+
+            const method_name = "subscribeEvent";
+            if (@hasDecl(@TypeOf(self.*), method_name)) {
+                self.subscribeEvent(messageQueue) catch @panic("PLUGIn");
+            } else {
+                utils.log("PLUGIN", std.fmt.comptimePrint("method \"{s}\" not implemented yet", .{method_name}));
+            }
+        }
+    };
+
+    return .{
+        .fnTable = obj._fnTable,
+        .context = obj,
+        .name = name,
+        .vtable = &.{
+            .subscribe = impl.subscribe,
+            .subscribeEvent = impl.subscribeEvent,
+        },
+        .envData = envData,
+        .queue = messages,
+    };
+}


### PR DESCRIPTION
Implement plugin feature on Lisp environment, the environment includes `registerPlugin` function, which allows to provide additional feature apart from lisp core interpreter. The plugin has its own function table which can be run in the Lisp environment when the plugin is registered. The plugin also supports `MessageQueue` struct which includes a simple message channel between the plugin and Lisp environment.

 - Add `reference` entity to denote internal reference key for function stored in the environment
 - Add `libxev` to add using async handler for a message system, such handler is handled in an additional thread
 - Provide `LispFunctionWithOpaque` type to support plugin functions, the function allows to access the plugin struct
 - Provide `PluginExample` as a plugin example, the plugin is registered in main program. The plugin shows simple get/set/add operation on the plugin struct