### PR TITLE
feat: Using plugin for shell history and editing functions

### DIFF
--- a/src/Frontend.zig
+++ b/src/Frontend.zig
@@ -44,10 +44,13 @@ pub const VTable = struct {
     /// TODO: For multiple bytes case it is incorrect now, like emoji input.
     /// This is handled using CHARPOS and BYTEPOS in Emacs, which helps mapping
     /// to the correct position.
-    deleteBackwardChar: *const fn (context: int_ptr, optional_arrayList: ?*ArrayList(u8), pos: usize) anyerror!void,
+    deleteBackwardChar: *const fn (context: int_ptr, pos: usize) anyerror!void,
 
     /// Read current position of the cursor in Position form.
     readCursorPos: *const fn (context: int_ptr) anyerror!Position,
+
+    /// Clear content stored in the frontend
+    clearContent: *const fn (context: *const anyopaque, pos: usize) anyerror!void,
 };
 
 pub fn print(self: Self, string: []const u8) !void {
@@ -66,12 +69,16 @@ pub fn insert(self: Self, optional_arrayList: ?*ArrayList(u8), byte: u8, pos: us
     try self.vtable.insert(self.context, optional_arrayList, byte, pos);
 }
 
-pub fn deleteBackwardChar(self: Self, optional_arrayList: ?*ArrayList(u8), pos: usize) !void {
-    try self.vtable.deleteBackwardChar(self.context, optional_arrayList, pos);
+pub fn deleteBackwardChar(self: Self, pos: usize) !void {
+    try self.vtable.deleteBackwardChar(self.context, pos);
 }
 
 pub fn readCursorPos(self: Self) !Position {
     return try self.vtable.readCursorPos(self.context);
+}
+
+pub fn clearContent(self: Self, pos: usize) !void {
+    return self.vtable.clearContent(self.context, pos);
 }
 
 const Self = @This();

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,7 @@ const Terminal = @import("terminal.zig").Terminal;
 
 const PluginExample = @import("plugin-example.zig").PluginExample;
 const PluginHistory = @import("plugin-history.zig").PluginHistory;
+const PluginEditing = @import("plugin-editing.zig").PluginEditing;
 
 const INIT_CONFIG_FILE = "init.el";
 
@@ -126,9 +127,6 @@ pub const Shell = struct {
     allocator: std.mem.Allocator,
     stdin: std.fs.File,
 
-    /// Denotes where the buffer cursor position is at to perform append
-    /// and delete action from that point.
-    buffer_pos: usize,
     /// Denotes the buffer cursor.
     buffer_cursor: Position,
     /// Current reader instance
@@ -186,12 +184,14 @@ pub const Shell = struct {
         const plugin_history = PluginHistory.init(allocator);
         env.*.registerPlugin(plugin_history) catch @panic("OOM");
 
+        const plugin_editing = PluginEditing.init(allocator);
+        env.*.registerPlugin(plugin_editing) catch @panic("OOM");
+
         const self = allocator.create(Shell) catch @panic("OOM");
         self.* = Shell{
             .allocator = allocator,
             .stdin = stdin,
             .logger = logger,
-            .buffer_pos = 0,
             .buffer_cursor = Position{
                 .x = 0,
                 .y = 0,
@@ -226,6 +226,25 @@ pub const Shell = struct {
         self.config.set = true;
     }
 
+    /// Eval statement directly, worked as a macro
+    // TODO: Consider adding error handling
+    fn eval_statement(self: Shell, statement: []const u8, print: bool) void {
+        const statement_reader = parsing_statement(statement);
+
+        const result = self.env.apply(statement_reader.ast_root) catch |err| {
+            utils.log("ERR", err);
+            return;
+        };
+        defer result.deinit();
+
+        if (print) {
+            const str = printer.pr_str(result, true);
+            utils.log("EVAL", str);
+        }
+
+        return;
+    }
+
     fn loadInitConfigFile(self: *Shell) !void {
         const load_statement = std.fmt.comptimePrint("(load \"{s}\")", .{INIT_CONFIG_FILE});
         const load_statement_reader = parsing_statement(load_statement);
@@ -252,16 +271,19 @@ pub const Shell = struct {
         var current_gpa = std.heap.GeneralPurposeAllocator(.{}){};
         const current_gpa_allocator = current_gpa.allocator();
 
+        // TODO: Consider making reading statement and parsing separated.(#42)
         const read_result = try self.*.read(current_gpa_allocator);
 
         try self.*.eval(self.curr_read.ast_root);
         // try self.*.print(read_result);
 
-        current_gpa_allocator.free(read_result);
+        _ = read_result;
+        // current_gpa_allocator.free(read_result);
     }
 
     // read from stdin and store the result via provided allocator.
     fn read(self: *Shell, allocator: std.mem.Allocator) ![]const u8 {
+        _ = allocator;
         // NOTE: The reading from stdin is now having two writer for different
         // ends. One is for stdout to display; Another is Arraylist to store
         // the string. Is this a good way to handle?
@@ -271,23 +293,25 @@ pub const Shell = struct {
 
         try self.frontend.print("\nuser> ");
 
-        var arrayList = ArrayList(u8).init(allocator);
-        errdefer {
-            arrayList.deinit();
-        }
-
         // TODO: Some mechanism to get the frontend input(generic way)
         // for parsing
         const stdin = self.*.stdin;
         const reader = stdin.reader();
         var reading = true;
+        var statement: []u8 = "";
 
         var history_plugin: ?*PluginHistory = null;
         if (self.*.env.plugins.get("PluginHistory")) |plugin| {
             history_plugin = @constCast(@ptrCast(@alignCast(plugin.context)));
         }
 
+        var editing_plugin: ?*PluginEditing = null;
+        if (self.*.env.plugins.get("PluginEditing")) |plugin| {
+            editing_plugin = @constCast(@ptrCast(@alignCast(plugin.context)));
+        }
+
         while (reading) {
+            var plugin_full_statement = editing_plugin.?.buffer;
             if (parsing_byte(reader)) |inputEvent| {
                 self.logger.logger()
                     .fmt("[LOG]", "InputEvent: {any}", .{inputEvent})
@@ -306,29 +330,36 @@ pub const Shell = struct {
                         // Backspace handling
                         if (key == .Backspace) {
                             // TODO: Functional key instead?
-                            if (arrayList.items.len == 0) {
-                                continue;
-                            }
+                            if (editing_plugin) |_editing_plugin| {
+                                if (_editing_plugin.buffer.items.len == 0) {
+                                    continue;
+                                }
 
-                            try self.frontend.deleteBackwardChar(&arrayList, self.buffer_pos);
-                            if (self.buffer_pos > 0) {
-                                self.buffer_pos -= 1;
+                                if (_editing_plugin.pos > 0) {
+                                    try self.frontend.deleteBackwardChar(_editing_plugin.pos);
+                                    _editing_plugin.orderedRemove(_editing_plugin.pos - 1);
+                                    _editing_plugin.moveBackward(1);
+                                }
                             }
                         } else if (inputEvent.ctrl and key == .J) {
-                            const statement = try arrayList.toOwnedSlice();
+                            var copied_statement = try plugin_full_statement.clone();
+                            defer copied_statement.deinit();
+                            statement = try copied_statement.toOwnedSlice();
 
                             // TODO: Shift-RET case is not handled yet. It returns same byte
                             // as only RET case, which needs to refer to io part.
                             // NOTE: Need to handle \n byte better
-                            try self.frontend.insert(null, '\n', self.buffer_pos);
+                            try self.frontend.insert(null, '\n', editing_plugin.?.pos);
                             reading = false;
 
-                            // TODO: Parsing the latest statement and store
+                            // TODO(#42): Parsing the latest statement and store
                             // in the Shell within the function. This makes
                             // function non-pure such that it makes testing
                             // more difficult. Need a more modular approach
                             // for this.
                             self.*.curr_read = parsing_statement(statement);
+
+                            try self.frontend.clearContent(editing_plugin.?.pos);
 
                             if (statement.len == 0) {
                                 continue;
@@ -341,7 +372,7 @@ pub const Shell = struct {
                             }
 
                             // Reset cursor
-                            self.buffer_pos = 0;
+                            editing_plugin.?.clear();
 
                             continue;
                         } else if (inputEvent.alt) {
@@ -349,8 +380,9 @@ pub const Shell = struct {
                             // points to the last one if there is no history
                             // navigating function run before.
                             if (key == .N or key == .P) {
-                                if (arrayList.items.len != 0) {
-                                    try self.*.clearLine(&arrayList);
+                                if (plugin_full_statement.items.len != 0) {
+                                    try self.frontend.clearContent(editing_plugin.?.pos);
+                                    editing_plugin.?.clear();
                                 }
 
                                 if (history_plugin) |plugin| {
@@ -370,13 +402,15 @@ pub const Shell = struct {
                                     }
                                 }
 
-                                self.buffer_pos = 0;
                                 if (history_plugin) |plugin| {
                                     const result = plugin.getHistoryItem(plugin.history_curr);
 
                                     for (result) |byte| {
-                                        try self.frontend.insert(&arrayList, byte, self.buffer_pos);
-                                        self.buffer_pos += 1;
+                                        if (editing_plugin) |_editing_plugin| {
+                                            try _editing_plugin.insert(_editing_plugin.pos, byte);
+                                            try self.frontend.insert(null, byte, _editing_plugin.pos);
+                                            _editing_plugin.moveForward(1);
+                                        }
                                     }
                                 }
                                 // Set to the previous one
@@ -394,8 +428,12 @@ pub const Shell = struct {
                             }
                             const bytes = inputEvent.raw;
                             for (bytes) |byte| {
-                                try self.frontend.insert(&arrayList, byte, self.buffer_pos);
-                                self.buffer_pos += 1;
+                                if (editing_plugin) |plugin| {
+                                    try plugin.insert(editing_plugin.?.pos, byte);
+                                }
+
+                                try self.frontend.insert(null, byte, editing_plugin.?.pos);
+                                editing_plugin.?.moveForward(1);
                             }
                         }
                     },
@@ -403,16 +441,16 @@ pub const Shell = struct {
                         // NOTE: Restrict for left and right only. No function
                         // yet on buffer.
                         if (key == .ArrowLeft) {
-                            if (self.buffer_pos > 0) {
+                            if (editing_plugin.?.pos > 0) {
                                 try self.frontend.move(1, .Left);
 
-                                self.buffer_pos -= 1;
+                                editing_plugin.?.moveBackward(1);
 
                                 const cursor = try self.frontend.readCursorPos();
                                 self.buffer_cursor = cursor;
                             }
                         } else if (key == .ArrowRight) {
-                            if (self.buffer_pos < arrayList.items.len) {
+                            if (editing_plugin.?.pos < plugin_full_statement.items.len) {
                                 const prevCursor = try self.frontend.readCursorPos();
 
                                 if (prevCursor.x == self.frontend.frame_size.x) {
@@ -423,7 +461,7 @@ pub const Shell = struct {
                                     try self.frontend.move(1, .Right);
                                 }
 
-                                self.buffer_pos += 1;
+                                editing_plugin.?.moveForward(1);
 
                                 const cursor = try self.frontend.readCursorPos();
                                 self.buffer_cursor = cursor;
@@ -434,22 +472,9 @@ pub const Shell = struct {
             } else |err| switch (err) {
                 else => |e| return e,
             }
-
-            logz.debug()
-                .fmt("[CURSOR]", "length: {d}", .{self.buffer_pos})
-                .log();
         }
 
-        return arrayList.toOwnedSlice();
-    }
-
-    fn clearLine(self: *Shell, arrayList: *ArrayList(u8)) !void {
-        // TODO: Provide efficient way for this one
-        for (0..arrayList.items.len) |_| {
-            try self.frontend.deleteBackwardChar(arrayList, self.buffer_pos);
-
-            self.buffer_pos -= 1;
-        }
+        return statement;
     }
 
     fn eval(self: *Shell, item: MalType) !void {

--- a/src/plugin-editing.zig
+++ b/src/plugin-editing.zig
@@ -1,0 +1,84 @@
+/// NOTE: Likely corrsponds to cmds.c and editfns.c in Emacs
+/// The actual insert function involves much more steps including bytes
+/// checking, properties inheritance, before/after hook etc.
+/// The design will be much simpler and to be developed until it is
+/// necessary to be compatiable further.
+const std = @import("std");
+const lisp = @import("types/lisp.zig");
+
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
+
+const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
+    .{ "insert", &insert },
+});
+
+fn insert(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    const bytes = try params[0].as_string();
+    const pos = try params[1].as_number();
+
+    const pluginEnv: *PluginEditing = @ptrCast(@alignCast(env));
+
+    for (bytes.items) |byte| {
+        pluginEnv.insert(pos.value, byte) catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
+    }
+
+    // Corresponds to nil
+    // TODO: See if extract this as a new type like Qnil.
+    return MalType{ .boolean = false };
+}
+
+pub const PluginEditing = struct {
+    _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
+
+    /// Using buffer as a whole for such feature in future, currently
+    /// it is a single local one.
+    buffer: std.ArrayList(u8),
+    /// Denotes the cursor position corresponds to the buffer
+    pos: usize,
+
+    pub fn init(allocator: std.mem.Allocator) *PluginEditing {
+        const self = allocator.create(PluginEditing) catch @panic("OOM");
+
+        const buffer = std.ArrayList(u8).init(allocator);
+        defer buffer.deinit();
+
+        self.* = .{
+            ._fnTable = EVAL_TABLE,
+            .buffer = buffer,
+            .pos = 0,
+        };
+
+        return self;
+    }
+
+    pub fn insert(self: *PluginEditing, pos: usize, byte: u8) !void {
+        const result = try self.buffer.insert(pos, byte);
+
+        return result;
+    }
+
+    pub fn reset(self: *PluginEditing) void {
+        self.pos = 0;
+    }
+
+    pub fn moveBackward(self: *PluginEditing, steps: usize) void {
+        self.pos -= steps;
+    }
+
+    pub fn moveForward(self: *PluginEditing, steps: usize) void {
+        self.pos += steps;
+    }
+
+    pub fn clear(self: *PluginEditing) void {
+        self.pos = 0;
+        return self.buffer.clearRetainingCapacity();
+    }
+
+    pub fn orderedRemove(self: *PluginEditing, pos: usize) void {
+        _ = self.buffer.orderedRemove(pos);
+    }
+};

--- a/src/plugin-history.zig
+++ b/src/plugin-history.zig
@@ -1,0 +1,48 @@
+/// NOTE: The original history in Emacs stored elsewhere. (add-to-history)
+/// function barely set an input with history command appended by various
+/// conditions given.
+const std = @import("std");
+const lisp = @import("types/lisp.zig");
+
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
+
+const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
+    .{ "get-history-len", &historyLen },
+    // .{ "add-plugin-value", &add },
+    // .{ "set-plugin-value", &set },
+});
+
+fn historyLen(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    _ = params;
+
+    const pluginEnv: *PluginHistory = @ptrCast(@alignCast(env));
+
+    return MalType{ .number = .{ .value = pluginEnv.history.items.len } };
+}
+
+pub const PluginHistory = struct {
+    _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
+
+    history: std.ArrayList([]u8),
+    history_curr: usize,
+
+    pub fn init(allocator: std.mem.Allocator) *PluginHistory {
+        const self = allocator.create(PluginHistory) catch @panic("OOM");
+
+        const historyArrayList = std.ArrayList([]u8).init(allocator);
+
+        self.* = .{
+            ._fnTable = EVAL_TABLE,
+            .history = historyArrayList,
+            .history_curr = 0,
+        };
+
+        return self;
+    }
+
+    pub fn getHistoryItem(self: *PluginHistory, index: usize) []const u8 {
+        return self.history.items[index];
+    }
+};


### PR DESCRIPTION
- Provide `PluginHistory` for basic command history functions in shell
- Provide `PluginEditing` for editing functions in shell

This decouples the shell directly using the zig function(As the plugin supports to expose lisp functions), provides ground to use keymap(#33) later.