### PR TITLE
feat: Basic keymap implementation

### DIFF
--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -1,5 +1,5 @@
 (def! keymap
-    [nil nil nil nil nil nil nil nil nil nil
+    [nil nil nil nil delete-char nil nil nil nil nil
     nil nil nil nil nil nil nil nil nil nil
     nil nil nil nil nil nil nil nil nil nil
     nil nil insert nil nil nil nil nil nil nil
@@ -11,6 +11,6 @@
     insert insert insert insert nil nil nil insert insert insert
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert insert
-    insert insert insert nil nil nil nil nil
+    insert insert insert nil nil nil nil delete-backward-char
     ]
     )

--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -1,5 +1,5 @@
 (def! keymap
-    [nil nil nil nil delete-char nil nil nil nil nil
+    [nil nil backward-char nil delete-char nil forward-char nil nil nil
     nil nil nil nil nil nil nil nil nil nil
     nil nil nil nil nil nil nil nil nil nil
     nil nil insert nil nil nil nil nil nil nil

--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -1,0 +1,16 @@
+(def! keymap
+    [nil nil nil nil nil nil nil nil nil nil
+    nil nil nil nil nil nil nil nil nil nil
+    nil nil nil nil nil nil nil nil nil nil
+    nil nil insert nil nil nil nil nil nil nil
+    insert insert insert insert insert insert insert insert insert insert
+    insert insert insert insert insert insert insert insert insert nil
+    nil nil nil nil nil insert insert insert insert insert
+    insert insert insert insert insert insert insert insert insert insert
+    insert insert insert insert insert insert insert insert insert insert
+    insert insert insert insert nil nil nil insert insert insert
+    insert insert insert insert insert insert insert insert insert insert
+    insert insert insert insert insert insert insert insert insert insert
+    insert insert insert nil nil nil nil nil
+    ]
+    )

--- a/src/Frontend.zig
+++ b/src/Frontend.zig
@@ -51,6 +51,9 @@ pub const VTable = struct {
 
     /// Clear content stored in the frontend
     clearContent: *const fn (context: *const anyopaque, pos: usize) anyerror!void,
+
+    /// Refresh the content in the frontend
+    refresh: *const fn (context: *const anyopaque, posStart: usize, charbefore: usize, modification: ?[]const u8) anyerror!void,
 };
 
 pub fn print(self: Self, string: []const u8) !void {
@@ -79,6 +82,10 @@ pub fn readCursorPos(self: Self) !Position {
 
 pub fn clearContent(self: Self, pos: usize) !void {
     return self.vtable.clearContent(self.context, pos);
+}
+
+pub fn refresh(self: Self, posStart: usize, charbefore: usize, modification: ?[]const u8) !void {
+    return self.vtable.refresh(self.context, posStart, charbefore, modification);
 }
 
 const Self = @This();

--- a/src/plugin-editing.zig
+++ b/src/plugin-editing.zig
@@ -16,15 +16,16 @@ const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
 
 fn insert(params: []MalType, env: *anyopaque) MalTypeError!MalType {
     const bytes = try params[0].as_string();
-    const pos = try params[1].as_number();
 
     const pluginEnv: *PluginEditing = @ptrCast(@alignCast(env));
 
     for (bytes.items) |byte| {
-        pluginEnv.insert(pos.value, byte) catch |err| switch (err) {
+        pluginEnv.insert(pluginEnv.pos, byte) catch |err| switch (err) {
             else => return MalTypeError.Unhandled,
         };
     }
+
+    pluginEnv.moveForward(1);
 
     // Corresponds to nil
     // TODO: See if extract this as a new type like Qnil.
@@ -59,6 +60,10 @@ pub const PluginEditing = struct {
         const result = try self.buffer.insert(pos, byte);
 
         return result;
+    }
+
+    pub fn append(self: *PluginEditing, byte: u8) !void {
+        return try self.buffer.append(byte);
     }
 
     pub fn reset(self: *PluginEditing) void {

--- a/src/plugin-editing.zig
+++ b/src/plugin-editing.zig
@@ -6,16 +6,82 @@
 const std = @import("std");
 const lisp = @import("types/lisp.zig");
 
+const Frontend = @import("Frontend.zig");
+
 const MalType = lisp.MalType;
 const MalTypeError = lisp.MalTypeError;
 const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
 
 const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
+    // Likely to be in original.
+    .{ "forward-char", forwardChar },
+    .{ "backward-char", backwardChar },
+
     .{ "insert", &insert },
     .{ "delete-char", &deleteChar },
     // Shortcut now. The original implementation are in elisp.
     .{ "delete-backward-char", &deleteBackwardChar },
 });
+
+fn forwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    var steps: lisp.Number = undefined;
+
+    if (params.len > 0) {
+        steps = params[0].as_number() catch |err| switch (err) {
+            else => .{ .value = 1 },
+        };
+    } else {
+        steps = .{ .value = 1 };
+    }
+
+    const self: *PluginEditing = @ptrCast(@alignCast(env));
+
+    if (self.buffer.items.len > self.pos) {
+        const prevCursor = self.frontend.readCursorPos() catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
+        if (prevCursor.x == self.frontend.frame_size.x) {
+            self.frontend.move(prevCursor.x - 1, .Left) catch |err| switch (err) {
+                else => return MalTypeError.Unhandled,
+            };
+            self.frontend.move(1, .Down) catch |err| switch (err) {
+                else => return MalTypeError.Unhandled,
+            };
+        } else {
+            self.frontend.move(1, .Right) catch |err| switch (err) {
+                else => return MalTypeError.Unhandled,
+            };
+        }
+    }
+
+    self.movePoint(steps.value, true);
+
+    return .{ .boolean = false };
+}
+
+fn backwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
+    var steps: lisp.Number = undefined;
+
+    if (params.len > 0) {
+        steps = params[0].as_number() catch |err| switch (err) {
+            else => .{ .value = 1 },
+        };
+    } else {
+        steps = .{ .value = 1 };
+    }
+
+    const self: *PluginEditing = @ptrCast(@alignCast(env));
+
+    if (self.pos > 0) {
+        self.frontend.move(1, .Left) catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
+    }
+
+    self.movePoint(steps.value, false);
+
+    return .{ .boolean = false };
+}
 
 fn insert(params: []MalType, env: *anyopaque) MalTypeError!MalType {
     const bytes = try params[0].as_string();
@@ -28,7 +94,11 @@ fn insert(params: []MalType, env: *anyopaque) MalTypeError!MalType {
         };
     }
 
-    pluginEnv.moveForward(1);
+    pluginEnv.movePoint(1, true);
+
+    pluginEnv.frontend.refresh(pluginEnv.pos - 1, 0, bytes.items) catch |err| switch (err) {
+        else => return MalTypeError.Unhandled,
+    };
 
     // Corresponds to nil
     // TODO: See if extract this as a new type like Qnil.
@@ -52,7 +122,10 @@ fn deleteChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
         }
 
         pluginEnv.replace(pluginEnv.pos, len.value, &.{});
-        // pluginEnv.moveBackward(1);
+
+        pluginEnv.frontend.refresh(pluginEnv.pos, 1, "") catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
     }
 
     return MalType{ .boolean = false };
@@ -73,7 +146,14 @@ fn deleteBackwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
         }
 
         pluginEnv.replace(pluginEnv.pos - 1, len.value, &.{});
-        pluginEnv.moveBackward(1);
+        pluginEnv.movePoint(1, false);
+
+        pluginEnv.frontend.move(1, .Left) catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
+        pluginEnv.frontend.refresh(pluginEnv.pos, 1, "") catch |err| switch (err) {
+            else => return MalTypeError.Unhandled,
+        };
     }
 
     return MalType{ .boolean = false };
@@ -81,6 +161,8 @@ fn deleteBackwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 
 pub const PluginEditing = struct {
     _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
+    /// Frontend interface
+    frontend: Frontend,
 
     /// Using buffer as a whole for such feature in future, currently
     /// it is a single local one.
@@ -88,7 +170,7 @@ pub const PluginEditing = struct {
     /// Denotes the cursor position corresponds to the buffer
     pos: usize,
 
-    pub fn init(allocator: std.mem.Allocator) *PluginEditing {
+    pub fn init(allocator: std.mem.Allocator, frontend: Frontend) *PluginEditing {
         const self = allocator.create(PluginEditing) catch @panic("OOM");
 
         const buffer = std.ArrayList(u8).init(allocator);
@@ -96,6 +178,7 @@ pub const PluginEditing = struct {
 
         self.* = .{
             ._fnTable = EVAL_TABLE,
+            .frontend = frontend,
             .buffer = buffer,
             .pos = 0,
         };
@@ -136,5 +219,22 @@ pub const PluginEditing = struct {
 
     pub fn orderedRemove(self: *PluginEditing, pos: usize) void {
         _ = self.buffer.orderedRemove(pos);
+    }
+
+    pub fn movePoint(self: *PluginEditing, steps: usize, forward: bool) void {
+        // NOTE: As @intCast is used, very big number is lost now.
+        const signed_steps: i64 = @intCast(steps);
+        const signed_pos: i64 = @intCast(self.pos);
+
+        var newPos = if (forward) signed_pos + signed_steps else signed_pos - signed_steps;
+
+        if (self.buffer.items.len < newPos) {
+            newPos = @intCast(self.buffer.items.len);
+        }
+        if (newPos < 0) {
+            newPos = 0;
+        }
+
+        self.pos = @intCast(newPos);
     }
 };

--- a/src/prefix-string-hash-map.zig
+++ b/src/prefix-string-hash-map.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+
+pub fn PrefixStringHashMap(comptime T: type) type {
+    return struct {
+        allocator: Allocator,
+        map: std.StringHashMap(T),
+        prefix: []const u8,
+
+        // Shortcut for type
+        const K = []const u8;
+        const Self = @This();
+
+        // Key count respect to the prefix
+        var keyCount: usize = 0;
+
+        pub fn init(allocator: Allocator, prefix: []const u8) Self {
+            const map = std.StringHashMap(T).init(allocator);
+
+            return .{
+                .allocator = allocator,
+                .map = map,
+                .prefix = prefix,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.map.deinit();
+        }
+
+        pub fn put(self: *Self, value: T) Allocator.Error!void {
+            const key = try std.fmt.allocPrint(self.allocator, "{s}-{d}", .{
+                self.prefix,
+                keyCount,
+            });
+            const result = self.map.put(key, value);
+            keyCount += 1;
+
+            return result;
+        }
+
+        /// Manual method to put into the map, reference usage only.
+        pub fn putManual(self: *Self, key: K, value: T) Allocator.Error!void {
+            return self.map.put(key, value);
+        }
+
+        pub fn iterator(self: *Self) std.StringHashMap(T).Iterator {
+            return self.map.iterator();
+        }
+    };
+}

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -78,6 +78,9 @@ pub fn pr_str(mal: MalType, print_readably: bool) []u8 {
             _ = string.pop();
             string.appendSlice("]") catch @panic("allocator error");
         },
+        .symbol => |symbol| {
+            string.appendSlice(symbol) catch @panic("allocator error");
+        },
         else => {},
     }
 

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -271,6 +271,7 @@ pub const Terminal = struct {
         try stdout_writer.print("{s}", .{string});
 
         try bw.flush(); // don't forget to flush
+    }
 
     /// Refresh the frontend layout.
     /// Instruction:

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -75,9 +75,11 @@ pub const MalType = union(enum) {
                 }
                 vector.deinit();
             },
-            .function => |func_with_env| {
-                func_with_env.deinit();
-            },
+            // NOTE: Using the root env to deinit, but it seems a bit
+            // magical?
+            // .function => |func_with_env| {
+            //     func_with_env.deinit();
+            // },
             else => {},
         }
     }

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -333,6 +333,25 @@ test "vector function - simple case" {
     try testing.expectEqualStrings("[1 2]", result);
 }
 
+test "vector function - simple symbol case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "(vector a)");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[a]", result);
+}
+
 test "vectorp function - truthy case" {
     const allocator = testing.allocator;
 

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -388,6 +388,45 @@ test "vectorp function - through let* to create variable case" {
     try testing.expectEqual(true, is_vector_var_statement_value_bool);
 }
 
+test "aref function - direct get from vector constructor" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var aref_statement = Reader.init(allocator, "(aref [1 2 3] 1)");
+    defer aref_statement.deinit();
+
+    try testing.expect(aref_statement.ast_root == .list);
+
+    const aref_statement_value = try env.apply(aref_statement.ast_root);
+
+    const result = printer.pr_str(aref_statement_value, true);
+    try testing.expectEqualStrings("2", result);
+}
+
+test "aref function - get from variable" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var def_statement = Reader.init(allocator, "(def! a [1 2 3])");
+    defer def_statement.deinit();
+
+    _ = try env.apply(def_statement.ast_root);
+
+    var aref_statement = Reader.init(allocator, "(aref a 1)");
+    defer aref_statement.deinit();
+
+    try testing.expect(aref_statement.ast_root == .list);
+
+    const aref_statement_value = try env.apply(aref_statement.ast_root);
+
+    const result = printer.pr_str(aref_statement_value, true);
+    try testing.expectEqualStrings("2", result);
+}
+
 test "fs-load function - normal case" {
     const allocator = testing.allocator;
 


### PR DESCRIPTION
Implement the basic for having lisp keymap and used that for various editing features.

 - Implement `aref` function, which allows to return the index of an element from vector
 - Implement simple garbage collection for vector data structure. The env stores values declared in a hash map prefixed by string, which allows to be deinit along with env deinit process.
 - Implement `refresh` function for frontend as a general way to update the frontend result
 - Implement `insert`, `delete-char`, `delete-backward-char`, `forward-char` and `backward-char` for keymap