### PR TITLE
feat: enhance number support and comparison fns

### DIFF
--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -5,7 +5,7 @@
     nil nil insert nil insert nil nil nil nil nil
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert nil
-    nil nil nil nil nil insert insert insert insert insert
+    nil insert nil nil nil insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert nil nil nil insert insert insert

--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -5,7 +5,7 @@
     nil nil insert nil insert nil nil nil nil nil
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert nil
-    nil insert nil nil nil insert insert insert insert insert
+    insert insert insert nil nil insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert nil nil nil insert insert insert

--- a/src/data.zig
+++ b/src/data.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+
+const logz = @import("logz");
+
 const token_reader = @import("reader.zig");
 const lisp = @import("types/lisp.zig");
 
@@ -13,7 +16,9 @@ pub const EVAL_TABLE = std.StaticStringMap(LispFunction).initComptime(.{
     .{ "-", &minus },
     .{ "*", &times },
     .{ "/", &quo },
-    // TODO: In Emacs it uses general arithcompare_driver function
+    // The original arithcompare function store the three comparing cases
+    // into three bits(less than/great than/equal) and masking the bit
+    // return the result by given the corresponding opeartions.
     .{ "=", &eqlsign },
 });
 

--- a/src/env.zig
+++ b/src/env.zig
@@ -146,7 +146,7 @@ fn countFunc(params: []MalType, env: *LispEnv) MalTypeError!MalType {
         };
 
         const list = try mal.as_list();
-        return .{ .number = .{ .value = @intCast(list.items.len) } };
+        return .{ .number = .{ .value = @floatFromInt(list.items.len) } };
     }
 
     return .{ .boolean = false };
@@ -189,12 +189,13 @@ fn arefFunc(params: []MalType, env: *LispEnv) MalTypeError!MalType {
         },
     };
     const vector = try array.as_vector();
-    const index = try params[1].as_number();
+    const index_num = try params[1].as_number();
+    const index = try index_num.to_usize();
 
     var result: MalType = MalType{ .boolean = false };
 
-    if (index.value < vector.items.len) {
-        result = vector.items[index.value];
+    if (index < vector.items.len) {
+        result = vector.items[index];
     }
 
     return result;

--- a/src/keymap_macos.zig
+++ b/src/keymap_macos.zig
@@ -78,7 +78,9 @@ pub const CharKey = enum(u8) {
     Key8,
     Key9,
     SemiColon = 0x3b,
+    LessThan = 0x3c,
     Equal = 0x3d,
+    GreaterThan = 0x3e,
 
     BracketSquareLeft = 0x5b,
     BackSlash = 0x5c,

--- a/src/plugin-editing.zig
+++ b/src/plugin-editing.zig
@@ -54,7 +54,8 @@ fn forwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
         }
     }
 
-    self.movePoint(steps.value, true);
+    const steps_value = try steps.to_usize();
+    self.movePoint(steps_value, true);
 
     return .{ .boolean = false };
 }
@@ -78,7 +79,8 @@ fn backwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
         };
     }
 
-    self.movePoint(steps.value, false);
+    const steps_value = try steps.to_usize();
+    self.movePoint(steps_value, false);
 
     return .{ .boolean = false };
 }
@@ -121,7 +123,8 @@ fn deleteChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
             len = .{ .value = 1 };
         }
 
-        pluginEnv.replace(pluginEnv.pos, len.value, &.{});
+        const len_value = try len.to_usize();
+        pluginEnv.replace(pluginEnv.pos, len_value, &.{});
 
         pluginEnv.frontend.refresh(pluginEnv.pos, 1, "") catch |err| switch (err) {
             else => return MalTypeError.Unhandled,
@@ -145,7 +148,8 @@ fn deleteBackwardChar(params: []MalType, env: *anyopaque) MalTypeError!MalType {
             len = .{ .value = 1 };
         }
 
-        pluginEnv.replace(pluginEnv.pos - 1, len.value, &.{});
+        const len_value = try len.to_usize();
+        pluginEnv.replace(pluginEnv.pos - 1, len_value, &.{});
         pluginEnv.movePoint(1, false);
 
         pluginEnv.frontend.move(1, .Left) catch |err| switch (err) {

--- a/src/plugin-example.zig
+++ b/src/plugin-example.zig
@@ -9,6 +9,7 @@ const MalType = lisp.MalType;
 const MalTypeError = lisp.MalTypeError;
 const LispFunction = lisp.LispFunction;
 const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
+const NumberType = lisp.NumberType;
 
 const MessageQueue = @import("message_queue.zig").MessageQueue;
 
@@ -25,7 +26,8 @@ fn get(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 
     const pluginEnv: *PluginExample = @ptrCast(@alignCast(env));
 
-    const result = MalType{ .number = .{ .value = pluginEnv.num } };
+    const value: NumberType = @floatFromInt(pluginEnv.num);
+    const result = MalType{ .number = .{ .value = value } };
 
     utils.log("get-plugin-value", pluginEnv.num);
 
@@ -39,7 +41,8 @@ fn add(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 
     pluginEnv.num += 1;
 
-    const result = MalType{ .number = .{ .value = pluginEnv.num } };
+    const value: NumberType = @floatFromInt(pluginEnv.num);
+    const result = MalType{ .number = .{ .value = value } };
 
     utils.log("set-plugin-value", pluginEnv.num);
 
@@ -51,7 +54,7 @@ fn set(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 
     const value = try params[0].as_number();
 
-    pluginEnv.num = value.value;
+    pluginEnv.num = try value.integer();
 
     return params[0];
 }
@@ -59,7 +62,7 @@ fn set(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 pub const PluginExample = struct {
     _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
 
-    num: u64,
+    num: i64,
 
     pub fn init(allocator: std.mem.Allocator) *PluginExample {
         const self = allocator.create(PluginExample) catch @panic("OOM");

--- a/src/plugin-history.zig
+++ b/src/plugin-history.zig
@@ -19,7 +19,8 @@ fn historyLen(params: []MalType, env: *anyopaque) MalTypeError!MalType {
 
     const pluginEnv: *PluginHistory = @ptrCast(@alignCast(env));
 
-    return MalType{ .number = .{ .value = pluginEnv.history.items.len } };
+    const value: lisp.NumberType = @floatFromInt(pluginEnv.history.items.len);
+    return MalType{ .number = .{ .value = value } };
 }
 
 pub const PluginHistory = struct {

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -345,7 +345,7 @@ pub const Reader = struct {
         if (isNumber) {
             mal = MalType{
                 .number = .{
-                    .value = utils.parseU64(token, 10) catch @panic("Unexpected overflow."),
+                    .value = std.fmt.parseFloat(f64, token) catch @panic("Unexpected overflow."),
                 },
             };
         } else if (isBoolean) |mal_bool| {

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -39,6 +39,14 @@ fn isDigit(char: u8) bool {
     return char >= '0' and char <= '9';
 }
 
+fn isSignChar(char: u8) bool {
+    return char == '+' or char == '-';
+}
+
+fn isValidNumberChar(char: u8) bool {
+    return isDigit(char) or char == '.' or isSignChar(char);
+}
+
 const LispEnv = @import("env.zig").LispEnv;
 
 // NOTE: Currently the regex requires fix to allow repeater after pipe('|')
@@ -311,8 +319,18 @@ pub const Reader = struct {
 
         var isNumber = true;
         var isString = false;
-        while (iter.next()) |char| {
-            if (!isDigit(char)) {
+        var point: usize = 0;
+        var i: usize = 0;
+        while (iter.next()) |char| : (i += 1) {
+            if (char == '.') {
+                point += 1;
+            }
+
+            if ((token.len == 1 and isSignChar(char)) or
+                !isValidNumberChar(char) or
+                point > 1 or
+                (i > 0 and isSignChar(char)))
+            {
                 isNumber = false;
             }
             if (!isString and iter.index == 1 and char == '\"' and token[token.len - 1] == '\"') {

--- a/tests/testing_lisp_general.zig
+++ b/tests/testing_lisp_general.zig
@@ -666,3 +666,302 @@ test "load function - normal case" {
     const result = printer.pr_str(load_statement_value, true);
     try testing.expectEqualStrings("1", result);
 }
+
+test "eq function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var eq_statement_1 = Reader.init(
+        allocator,
+        "(= 0 0)",
+    );
+    defer eq_statement_1.deinit();
+
+    const eq_statement_value_1 = try env.apply(eq_statement_1.ast_root);
+    defer eq_statement_value_1.deinit();
+
+    const result_1 = printer.pr_str(eq_statement_value_1, true);
+    try testing.expectEqualStrings("t", result_1);
+
+    var eq_statement_2 = Reader.init(
+        allocator,
+        "(= 0 1)",
+    );
+    defer eq_statement_2.deinit();
+
+    const eq_statement_value_2 = try env.apply(eq_statement_2.ast_root);
+    defer eq_statement_value_2.deinit();
+
+    const result_2 = printer.pr_str(eq_statement_value_2, true);
+    try testing.expectEqualStrings("nil", result_2);
+
+    var eq_statement_3 = Reader.init(
+        allocator,
+        "(= 1 1 1)",
+    );
+    defer eq_statement_3.deinit();
+
+    const eq_statement_value_3 = try env.apply(eq_statement_3.ast_root);
+    defer eq_statement_value_3.deinit();
+
+    const result_3 = printer.pr_str(eq_statement_value_3, true);
+    try testing.expectEqualStrings("t", result_3);
+
+    var eq_statement_4 = Reader.init(
+        allocator,
+        "(= 1 1 0)",
+    );
+    defer eq_statement_4.deinit();
+
+    const eq_statement_value_4 = try env.apply(eq_statement_4.ast_root);
+    defer eq_statement_value_4.deinit();
+
+    const result_4 = printer.pr_str(eq_statement_value_4, true);
+    try testing.expectEqualStrings("nil", result_4);
+}
+
+test "lss function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var lss_statement_1 = Reader.init(
+        allocator,
+        "(< 1 2)",
+    );
+    defer lss_statement_1.deinit();
+
+    const lss_statement_value_1 = try env.apply(lss_statement_1.ast_root);
+    defer lss_statement_value_1.deinit();
+
+    const result_1 = printer.pr_str(lss_statement_value_1, true);
+    try testing.expectEqualStrings("t", result_1);
+
+    var lss_statement_2 = Reader.init(
+        allocator,
+        "(< 1 2 2)",
+    );
+    defer lss_statement_2.deinit();
+
+    const lss_statement_value_2 = try env.apply(lss_statement_2.ast_root);
+    defer lss_statement_value_2.deinit();
+
+    const result_2 = printer.pr_str(lss_statement_value_2, true);
+    try testing.expectEqualStrings("nil", result_2);
+
+    var lss_statement_3 = Reader.init(
+        allocator,
+        "(< 3 2)",
+    );
+    defer lss_statement_3.deinit();
+
+    const lss_statement_value_3 = try env.apply(lss_statement_3.ast_root);
+    defer lss_statement_value_3.deinit();
+
+    const result_3 = printer.pr_str(lss_statement_value_3, true);
+    try testing.expectEqualStrings("nil", result_3);
+
+    var lss_statement_4 = Reader.init(
+        allocator,
+        "(< 2 2)",
+    );
+    defer lss_statement_4.deinit();
+
+    const lss_statement_value_4 = try env.apply(lss_statement_4.ast_root);
+    defer lss_statement_value_4.deinit();
+
+    const result_4 = printer.pr_str(lss_statement_value_4, true);
+    try testing.expectEqualStrings("nil", result_4);
+}
+
+test "leq function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var leq_statement_1 = Reader.init(
+        allocator,
+        "(<= 1 2)",
+    );
+    defer leq_statement_1.deinit();
+
+    const leq_statement_value_1 = try env.apply(leq_statement_1.ast_root);
+    defer leq_statement_value_1.deinit();
+
+    const result_1 = printer.pr_str(leq_statement_value_1, true);
+    try testing.expectEqualStrings("t", result_1);
+
+    var leq_statement_2 = Reader.init(
+        allocator,
+        "(<= 1 2 2)",
+    );
+    defer leq_statement_2.deinit();
+
+    const leq_statement_value_2 = try env.apply(leq_statement_2.ast_root);
+    defer leq_statement_value_2.deinit();
+
+    const result_2 = printer.pr_str(leq_statement_value_2, true);
+    try testing.expectEqualStrings("t", result_2);
+
+    var leq_statement_3 = Reader.init(
+        allocator,
+        "(<= 3 2)",
+    );
+    defer leq_statement_3.deinit();
+
+    const leq_statement_value_3 = try env.apply(leq_statement_3.ast_root);
+    defer leq_statement_value_3.deinit();
+
+    const result_3 = printer.pr_str(leq_statement_value_3, true);
+    try testing.expectEqualStrings("nil", result_3);
+
+    var leq_statement_4 = Reader.init(
+        allocator,
+        "(<= 2 2)",
+    );
+    defer leq_statement_4.deinit();
+
+    const leq_statement_value_4 = try env.apply(leq_statement_4.ast_root);
+    defer leq_statement_value_4.deinit();
+
+    const result_4 = printer.pr_str(leq_statement_value_4, true);
+    try testing.expectEqualStrings("t", result_4);
+
+    var leq_statement_5 = Reader.init(
+        allocator,
+        "(<= 3 1 2)",
+    );
+    defer leq_statement_5.deinit();
+
+    const leq_statement_value_5 = try env.apply(leq_statement_5.ast_root);
+    defer leq_statement_value_5.deinit();
+
+    const result_5 = printer.pr_str(leq_statement_value_5, true);
+    try testing.expectEqualStrings("nil", result_5);
+}
+
+test "gtr function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var gtr_statement_1 = Reader.init(
+        allocator,
+        "(> 2 1)",
+    );
+    defer gtr_statement_1.deinit();
+
+    const gtr_statement_value_1 = try env.apply(gtr_statement_1.ast_root);
+    defer gtr_statement_value_1.deinit();
+
+    const result_1 = printer.pr_str(gtr_statement_value_1, true);
+    try testing.expectEqualStrings("t", result_1);
+
+    var gtr_statement_2 = Reader.init(
+        allocator,
+        "(> 2 1 1)",
+    );
+    defer gtr_statement_2.deinit();
+
+    const gtr_statement_value_2 = try env.apply(gtr_statement_2.ast_root);
+    defer gtr_statement_value_2.deinit();
+
+    const result_2 = printer.pr_str(gtr_statement_value_2, true);
+    try testing.expectEqualStrings("nil", result_2);
+
+    var gtr_statement_3 = Reader.init(
+        allocator,
+        "(> 2 3)",
+    );
+    defer gtr_statement_3.deinit();
+
+    const gtr_statement_value_3 = try env.apply(gtr_statement_3.ast_root);
+    defer gtr_statement_value_3.deinit();
+
+    const result_3 = printer.pr_str(gtr_statement_value_3, true);
+    try testing.expectEqualStrings("nil", result_3);
+
+    var gtr_statement_4 = Reader.init(
+        allocator,
+        "(> 2 2)",
+    );
+    defer gtr_statement_4.deinit();
+
+    const gtr_statement_value_4 = try env.apply(gtr_statement_4.ast_root);
+    defer gtr_statement_value_4.deinit();
+
+    const result_4 = printer.pr_str(gtr_statement_value_4, true);
+    try testing.expectEqualStrings("nil", result_4);
+}
+
+test "geq function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var geq_statement_1 = Reader.init(
+        allocator,
+        "(>= 2 1)",
+    );
+    defer geq_statement_1.deinit();
+
+    const geq_statement_value_1 = try env.apply(geq_statement_1.ast_root);
+    defer geq_statement_value_1.deinit();
+
+    const result_1 = printer.pr_str(geq_statement_value_1, true);
+    try testing.expectEqualStrings("t", result_1);
+
+    var geq_statement_2 = Reader.init(
+        allocator,
+        "(>= 2 2 1)",
+    );
+    defer geq_statement_2.deinit();
+
+    const geq_statement_value_2 = try env.apply(geq_statement_2.ast_root);
+    defer geq_statement_value_2.deinit();
+
+    const result_2 = printer.pr_str(geq_statement_value_2, true);
+    try testing.expectEqualStrings("t", result_2);
+
+    var geq_statement_3 = Reader.init(
+        allocator,
+        "(>= 2 3)",
+    );
+    defer geq_statement_3.deinit();
+
+    const geq_statement_value_3 = try env.apply(geq_statement_3.ast_root);
+    defer geq_statement_value_3.deinit();
+
+    const result_3 = printer.pr_str(geq_statement_value_3, true);
+    try testing.expectEqualStrings("nil", result_3);
+
+    var geq_statement_4 = Reader.init(
+        allocator,
+        "(>= 2 2)",
+    );
+    defer geq_statement_4.deinit();
+
+    const geq_statement_value_4 = try env.apply(geq_statement_4.ast_root);
+    defer geq_statement_value_4.deinit();
+
+    const result_4 = printer.pr_str(geq_statement_value_4, true);
+    try testing.expectEqualStrings("t", result_4);
+
+    var geq_statement_5 = Reader.init(
+        allocator,
+        "(>= 3 1 2)",
+    );
+    defer geq_statement_5.deinit();
+
+    const geq_statement_value_5 = try env.apply(geq_statement_5.ast_root);
+    defer geq_statement_value_5.deinit();
+
+    const result_5 = printer.pr_str(geq_statement_value_5, true);
+    try testing.expectEqualStrings("nil", result_5);
+}


### PR DESCRIPTION
Changing the underlying type for Number to be `f64` to support floating point and negative number.

Implement comparison functions in lisp.