### PR TITLE
feat: replace using C-c to quit program through `quit` function

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -344,6 +344,9 @@ pub const Shell = struct {
 
                 switch (inputEvent.key) {
                     .char => |key| {
+                        if (inputEvent.ctrl and key == .C) {
+                            self.quit();
+                        }
                         // New entry point
                         if (inputEvent.ctrl and key == .J) {
                             var copied_statement = try plugin_full_statement.clone();
@@ -503,6 +506,7 @@ pub const Shell = struct {
 
     pub fn quit(self: *Shell) void {
         self.*.frontend.deinit();
+        self.*.env.deinit();
         self.*.deinit();
         std.process.exit(0);
     }

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -383,6 +383,8 @@ pub const Terminal = struct {
         attrs.c_lflag ^= c.ICANON;
         // Disable ECHO flag; Don't echo input characters
         attrs.c_lflag ^= c.ECHO;
+        // Disable SIGINT flag;
+        attrs.c_lflag ^= c.ISIG;
 
         // attrs.c_cc = self.prog_termios.cc;
         const stdin_fd = self.stdin_fd;


### PR DESCRIPTION
Previously key C-c directly sends SIGINT signal to the program and kills it, which bypass the program `quit` function. By disabling the corresponding signal flag, the key can now be read in the program and run `quit` function for various `deinit` jobs.