### PR TITLE
fix: escape character in reader and printer for ", \ and newline

### DIFF
--- a/global-keymap.lisp
+++ b/global-keymap.lisp
@@ -2,7 +2,7 @@
     [nil nil backward-char nil delete-char nil forward-char nil nil nil
     nil nil nil nil nil nil nil nil nil nil
     nil nil nil nil nil nil nil nil nil nil
-    nil nil insert nil insert nil nil nil nil nil
+    nil nil insert insert insert nil nil nil nil nil
     insert insert insert insert insert insert insert insert insert insert
     insert insert insert insert insert insert insert insert insert nil
     insert insert insert nil nil insert insert insert insert insert

--- a/src/main.zig
+++ b/src/main.zig
@@ -479,7 +479,7 @@ pub const Shell = struct {
                                 if (!std.mem.eql(u8, result_statement, "nil")) {
                                     var final_statement: []u8 = undefined;
                                     var str: []const u8 = &[_]u8{byte};
-                                    if (byte == '"') {
+                                    if (byte == '"' or byte == '\\') {
                                         str = &[_]u8{ '\\', byte };
                                     }
 


### PR DESCRIPTION
 - Allow inserting "\\" in interactive environment
 - Change the printer to show the actual representation and printed representation for different print_readably
 - Fix the reader implementation to store " and \ correctly