### PR TITLE
fix: remove panic method in test runner

### DIFF
--- a/test_runner.zig
+++ b/test_runner.zig
@@ -303,15 +303,6 @@ const Env = struct {
     }
 };
 
-pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
-    _ = error_return_trace;
-
-    if (current_test) |ct| {
-        std.debug.print("\x1b[31m{s}\npanic running \"{s}\"\n{s}\x1b[0m\n", .{ BORDER, ct, BORDER });
-    }
-    std.debug.panicExtra(ret_addr, "{s}", .{msg});
-}
-
 fn isUnnamed(t: std.builtin.TestFn) bool {
     const marker = ".test_";
     const test_name = t.name;


### PR DESCRIPTION
This solves infinite panic test message in running test cases with error like segmentation fault.