### PR TITLE
refactor: provide functions in env previously in env based on pointer implementation

### DIFF
--- a/src/env_ptr.zig
+++ b/src/env_ptr.zig
@@ -59,6 +59,7 @@ pub const SPECIAL_ENV_EVAL_TABLE = std.StaticStringMap(LispFunctionPtrWithEnv).i
     .{ "list", &listFunc },
     .{ "listp", &isListFunc },
     .{ "emptyp", &isEmptyFunc },
+    .{ "count", &countFunc },
 
     .{ "vector", &vectorFunc },
     .{ "aref", &arefFunc },
@@ -214,6 +215,26 @@ fn isEmptyFunc(params: []*MalType, env: *LispEnv) MalTypeError!*MalType {
         const empty = list.items.len == 0;
 
         return MalType.new_boolean_ptr(empty);
+    }
+
+    return MalType.new_boolean_ptr(false);
+}
+
+fn countFunc(params: []*MalType, env: *LispEnv) MalTypeError!*MalType {
+    const isList = try (try isListFunc(params, env)).as_boolean();
+
+    if (isList) {
+        const mal = get(params, env) catch |err| switch (err) {
+            error.IllegalType => blk: {
+                break :blk params[0];
+            },
+            else => {
+                return err;
+            },
+        };
+
+        const list = try mal.as_list();
+        return MalType.new_number(env.allocator, @floatFromInt(list.items.len));
     }
 
     return MalType.new_boolean_ptr(false);

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -103,7 +103,7 @@ pub const VectorData = struct {
 };
 
 pub const FunctionData = struct {
-    // allocator: std.mem.Allocator,
+    allocator: std.mem.Allocator,
     data: *LispEnv,
     reference_count: ReferenceCountType = 1,
 };
@@ -120,14 +120,14 @@ pub const MalType = union(enum) {
     /// General symbol type including function keyword
     symbol: SymbolData,
 
-    function: *LispEnv,
+    function: FunctionData,
 
     SExprEnd,
     VectorExprEnd,
     /// Incompleted type from parser
     Incompleted: void,
     /// Undefined param for function
-    Undefined,
+    Undefined: void,
 
     pub fn format(self: MalType, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = options;
@@ -181,6 +181,7 @@ pub const MalType = union(enum) {
                     }
                 },
                 .vector => |vector| {
+                    try std.fmt.format(writer, "count: {d}", .{vector.reference_count});
                     try std.fmt.format(writer, ".vector: ", .{});
                     for (vector.data.items, 0..) |item, i| {
                         try writer.writeAll("{ ");
@@ -188,18 +189,21 @@ pub const MalType = union(enum) {
                         try writer.writeAll(" }");
                     }
                 },
+                .function => |func| {
+                    try std.fmt.format(writer, "count: {d}", .{func.reference_count});
+                    try std.fmt.format(writer, ".function: ", .{});
+                    try std.fmt.format(writer, "{any}", .{func.data});
+                },
                 // NOTE: This is no way to use default format now as
                 // the implementation checks if the struct has "format"
                 // method or not for custom formatting
-                else => {
-                    try std.fmt.format(writer, "{any!}", .{self});
-                },
             }
             try writer.writeAll("}");
         }
     }
 
     pub const INCOMPLETED = @constCast(&MalType{ .Incompleted = undefined });
+    pub const UNDEFINED = @constCast(&MalType{ .Undefined = undefined });
     pub const TRUE = @constCast(&MalType{ .boolean = true });
     pub const FALSE = @constCast(&MalType{ .boolean = false });
 
@@ -301,6 +305,20 @@ pub const MalType = union(enum) {
         return mal_ptr;
     }
 
+    pub fn new_function_ptr(data: *LispEnv) *MalType {
+        const allocator = data.allocator;
+        const mal_ptr = allocator.create(MalType) catch @panic("OOM");
+
+        mal_ptr.* = .{
+            .function = .{
+                .allocator = allocator,
+                .data = data,
+            },
+        };
+
+        return mal_ptr;
+    }
+
     pub fn deinit(self: *MalType) void {
         utils.log("DEINIT entry", "{*}; {any}", .{ self, self }, .{ .test_only = true });
 
@@ -338,11 +356,12 @@ pub const MalType = union(enum) {
 
                 vector.allocator.destroy(self);
             },
-            // NOTE: Using the root env to deinit, but it seems a bit
-            // magical?
-            // .function => |func_with_env| {
-            //     func_with_env.deinit();
-            // },
+            .function => |func| {
+                // NOTE: Except lambda cases, All env are deinit through root env.
+                func.data.deinit();
+
+                func.allocator.destroy(self);
+            },
             else => {},
         }
     }
@@ -482,6 +501,15 @@ pub const MalType = union(enum) {
         }
     }
 
+    pub fn as_function_ptr(self: *MalType) MalTypeError!*LispEnv {
+        switch (self.*) {
+            .function => |func| {
+                return func.data;
+            },
+            else => return MalTypeError.IllegalType,
+        }
+    }
+
     /// Increase reference count for a lisp object.
     pub fn incref(self: *MalType) void {
         // A procedure instead of a function returning its argument
@@ -494,6 +522,7 @@ pub const MalType = union(enum) {
             .number,       => |*l| l.reference_count += 1,
             .string        => |*l| l.reference_count += 1,
             .symbol              => |*l| l.reference_count += 1,
+            .function      => |*l| l.reference_count += 1,
             else => {},
             // .fncore                    => |*l| l.reference_count += 1,
             // .func                      => |*l| l.reference_count += 1,
@@ -553,6 +582,14 @@ pub const MalType = union(enum) {
 
                 l.reference_count -= 1;
                 if (l.reference_count == 0) {
+                    self.deinit();
+                }
+            },
+            .function => |*func| {
+                if (func.reference_count == 0) return;
+
+                func.reference_count -= 1;
+                if (func.reference_count == 0) {
                     self.deinit();
                 }
             },

--- a/src/types/lisp.zig
+++ b/src/types/lisp.zig
@@ -332,7 +332,7 @@ pub const MalType = union(enum) {
             },
             .vector => |*vector| {
                 for (vector.data.items) |item| {
-                    item.deinit();
+                    item.decref();
                 }
                 vector.data.deinit(vector.allocator);
 

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -322,3 +322,39 @@ test "listp function - falsy case" {
     const result = printer.pr_str(listp_statement_value, true);
     try testing.expectEqualStrings("nil", result);
 }
+
+test "emptyp function - truthy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var emptyp_statement = Reader.init(allocator, "(emptyp (list))");
+    defer emptyp_statement.deinit();
+
+    try testing.expect(emptyp_statement.ast_root.* == .list);
+
+    const emptyp_statement_value = try env.apply(emptyp_statement.ast_root, false);
+    emptyp_statement_value.decref();
+
+    const result = printer.pr_str(emptyp_statement_value, true);
+    try testing.expectEqualStrings("t", result);
+}
+
+test "emptyp function - falsy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var emptyp_statement = Reader.init(allocator, "(emptyp (list 1))");
+    defer emptyp_statement.deinit();
+
+    try testing.expect(emptyp_statement.ast_root.* == .list);
+
+    const emptyp_statement_value = try env.apply(emptyp_statement.ast_root, false);
+    emptyp_statement_value.decref();
+
+    const result = printer.pr_str(emptyp_statement_value, true);
+    try testing.expectEqualStrings("nil", result);
+}

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -358,3 +358,22 @@ test "emptyp function - falsy case" {
     const result = printer.pr_str(emptyp_statement_value, true);
     try testing.expectEqualStrings("nil", result);
 }
+
+test "count function" {
+    // if (true) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var count_statement = Reader.init(allocator, "(count (list 1 2 \"1\"))");
+    defer count_statement.deinit();
+
+    try testing.expect(count_statement.ast_root.* == .list);
+
+    const count_statement_value = try env.apply(count_statement.ast_root, false);
+    defer count_statement_value.deinit();
+
+    const result = printer.pr_str(count_statement_value, true);
+    try testing.expectEqualStrings("3", result);
+}

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -377,3 +377,122 @@ test "count function" {
     const result = printer.pr_str(count_statement_value, true);
     try testing.expectEqualStrings("3", result);
 }
+
+test "[] syntax to create vector - simple case" {
+    // if (true) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "[1 2]");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root.* == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[1 2]", result);
+}
+
+test "vector function - simple case" {
+    // if (true) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "(vector 1 2)");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root.* == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[1 2]", result);
+}
+
+test "vector function - simple symbol case" {
+    // if (true) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vector_statement = Reader.init(allocator, "(vector a)");
+    defer vector_statement.deinit();
+
+    try testing.expect(vector_statement.ast_root.* == .list);
+
+    // NOTE: This is not a primitive value, thus require manual deinit.
+    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
+    defer vector_statement_value.deinit();
+
+    const result = printer.pr_str(vector_statement_value, true);
+    try testing.expectEqualStrings("[a]", result);
+}
+
+test "vectorp function - truthy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vectorp_statement = Reader.init(allocator, "(vectorp (vector 1 2))");
+    defer vectorp_statement.deinit();
+
+    try testing.expect(vectorp_statement.ast_root.* == .list);
+
+    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root, false);
+    defer vectorp_statement_value.decref();
+
+    const result = printer.pr_str(vectorp_statement_value, true);
+    try testing.expectEqualStrings("t", result);
+}
+
+test "vectorp function - falsy case" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var vectorp_statement = Reader.init(allocator, "(vectorp nil)");
+    defer vectorp_statement.deinit();
+
+    try testing.expect(vectorp_statement.ast_root.* == .list);
+
+    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root, false);
+    defer vectorp_statement_value.decref();
+
+    const result = printer.pr_str(vectorp_statement_value, true);
+    try testing.expectEqualStrings("nil", result);
+}
+
+test "vectorp function - through let* to create variable case" {
+    // if (true) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var is_vector_var_statement = Reader.init(
+        allocator,
+        "(let* ((vector_param (vector 1 2))) (vectorp vector_param))",
+    );
+    defer is_vector_var_statement.deinit();
+
+    const is_vector_var_statement_value = try env.apply(is_vector_var_statement.ast_root, false);
+    defer is_vector_var_statement_value.decref();
+
+    const result = printer.pr_str(is_vector_var_statement_value, true);
+    try testing.expectEqualStrings("t", result);
+
+    const is_vector_var_statement_value_bool = is_vector_var_statement_value.as_boolean() catch unreachable;
+    try testing.expectEqual(true, is_vector_var_statement_value_bool);
+}

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -496,3 +496,44 @@ test "vectorp function - through let* to create variable case" {
     const is_vector_var_statement_value_bool = is_vector_var_statement_value.as_boolean() catch unreachable;
     try testing.expectEqual(true, is_vector_var_statement_value_bool);
 }
+
+test "aref function - direct get from vector constructor" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var aref_statement = Reader.init(allocator, "(aref [1 2 3] 1)");
+    defer aref_statement.deinit();
+
+    try testing.expect(aref_statement.ast_root.* == .list);
+
+    const aref_statement_value = try env.apply(aref_statement.ast_root, false);
+    defer aref_statement_value.decref();
+
+    const result = printer.pr_str(aref_statement_value, true);
+    try testing.expectEqualStrings("2", result);
+}
+
+test "aref function - get from variable" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var def_statement = Reader.init(allocator, "(def! a [1 2 3])");
+    defer def_statement.deinit();
+
+    _ = try env.apply(def_statement.ast_root, false);
+
+    var aref_statement = Reader.init(allocator, "(aref a 1)");
+    defer aref_statement.deinit();
+
+    try testing.expect(aref_statement.ast_root.* == .list);
+
+    const aref_statement_value = try env.apply(aref_statement.ast_root, false);
+    defer aref_statement_value.decref();
+
+    const result = printer.pr_str(aref_statement_value, true);
+    try testing.expectEqualStrings("2", result);
+}


### PR DESCRIPTION
Provide the following functions in `env_ptr.zig`
- `emptyp`
- `count`
- `vectorp`
- `lambda`

See more: #58