### PR TITLE
feat: provide printing functions in env

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -27,6 +27,7 @@ const Terminal = @import("terminal.zig").Terminal;
 const PluginExample = @import("plugin-example.zig").PluginExample;
 const PluginHistory = @import("plugin-history.zig").PluginHistory;
 const PluginEditing = @import("plugin-editing.zig").PluginEditing;
+const PluginPrint = @import("plugin-print.zig").PluginPrint;
 
 const INIT_CONFIG_FILE = "init.el";
 
@@ -217,10 +218,13 @@ pub const Shell = struct {
         // env.*.registerPlugin(plugin_example) catch @panic("OOM");
 
         const plugin_history = PluginHistory.init(allocator);
-        env.*.registerPlugin(plugin_history) catch @panic("OOM");
+        env.registerPlugin(plugin_history) catch @panic("OOM");
 
         const plugin_editing = PluginEditing.init(allocator, frontend);
-        env.*.registerPlugin(plugin_editing) catch @panic("OOM");
+        env.registerPlugin(plugin_editing) catch @panic("OOM");
+
+        const plugin_print = PluginPrint.init(allocator, frontend);
+        env.registerPlugin(plugin_print) catch @panic("OOM");
 
         const self = allocator.create(Shell) catch @panic("OOM");
         self.* = Shell{

--- a/src/plugin-print.zig
+++ b/src/plugin-print.zig
@@ -1,0 +1,71 @@
+/// Plugin for print purpose, this requires to access frontend such that
+/// this separates function in env.zig, which those core functions shall require
+/// no frontend access at all.
+const std = @import("std");
+const lisp = @import("types/lisp.zig");
+
+const Frontend = @import("Frontend.zig");
+const printer = @import("printer.zig");
+
+const core_env = @import("env_ptr.zig");
+
+const ArrayList = std.ArrayList;
+
+const MalType = lisp.MalType;
+const MalTypeError = lisp.MalTypeError;
+const LispFunctionWithOpaque = lisp.LispFunctionWithOpaque;
+
+const EVAL_TABLE = std.StaticStringMap(LispFunctionWithOpaque).initComptime(.{
+    .{ "prn", &prnFunc },
+    .{ "println", &printlnFunc },
+});
+
+fn prnFunc(params: []*MalType, env: *anyopaque) MalTypeError!*MalType {
+    const pluginEnv: *PluginPrint = @ptrCast(@alignCast(env));
+
+    const result = try core_env.strPrintImpl(pluginEnv.allocator, params, .{
+        .join_with_space = true,
+        .print_readably = true,
+    });
+
+    // TODO: Need error handling
+    pluginEnv.frontend.print(printer.pr_str(result, false)) catch unreachable;
+    pluginEnv.frontend.print("\n") catch unreachable;
+
+    return MalType.new_boolean_ptr(false);
+}
+
+fn printlnFunc(params: []*MalType, env: *anyopaque) MalTypeError!*MalType {
+    const pluginEnv: *PluginPrint = @ptrCast(@alignCast(env));
+
+    const result = try core_env.strPrintImpl(pluginEnv.allocator, params, .{
+        .join_with_space = true,
+        .print_readably = false,
+    });
+
+    // TODO: Need error handling
+    pluginEnv.frontend.print(printer.pr_str(result, false)) catch unreachable;
+    pluginEnv.frontend.print("\n") catch unreachable;
+
+    return MalType.new_boolean_ptr(false);
+}
+
+pub const PluginPrint = struct {
+    _fnTable: std.StaticStringMap(LispFunctionWithOpaque),
+    /// Allocator
+    allocator: std.mem.Allocator,
+    /// Frontend interface
+    frontend: Frontend,
+
+    pub fn init(allocator: std.mem.Allocator, frontend: Frontend) *PluginPrint {
+        const self = allocator.create(PluginPrint) catch @panic("OOM");
+
+        self.* = .{
+            ._fnTable = EVAL_TABLE,
+            .allocator = allocator,
+            .frontend = frontend,
+        };
+
+        return self;
+    }
+};

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -90,13 +90,13 @@ pub fn pr_str(mal: *MalType, print_readably: bool) []u8 {
         },
         .list => |list| {
             string.appendSlice(allocator, "(") catch @panic("allocator error");
-            for (list.data.items) |item| {
+            for (list.data.items, 1..) |item, index| {
                 const result = pr_str(item, print_readably);
                 string.appendSlice(allocator, result) catch @panic("allocator error");
-                string.appendSlice(allocator, " ") catch @panic("allocator error");
+                if (index != list.data.items.len) {
+                    string.appendSlice(allocator, " ") catch @panic("allocator error");
+                }
             }
-            // Remove the last space
-            _ = string.pop();
             string.appendSlice(allocator, ")") catch @panic("allocator error");
         },
         .function => |_| {

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -66,13 +66,11 @@ pub fn pr_str(mal: *MalType, print_readably: bool) []u8 {
                 }
 
                 if (char == '\\') {
-                    if (iter.peek()) |peek| {
-                        if (peek == '\\') {
-                            if (print_readably) {
-                                string.append(allocator, '\\') catch @panic("allocator error");
-                            } else {
-                                // TODO: Handle non print_readably case
-                            }
+                    if (iter.peek()) |_| {
+                        if (print_readably) {
+                            string.append(allocator, '\\') catch @panic("allocator error");
+                        } else {
+                            // TODO: Handle non print_readably case
                         }
                     } else {
                         // NOTE: For single "\" case in data

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -14,6 +14,42 @@ const MalTypeError = lisp.MalTypeError;
 
 const utils = @import("../src/utils.zig");
 
+/// Simple macro function for testing lisp statement and result.
+fn testLispFn(statement: []const u8, expectedResult: []const u8) !void {
+    return testLispFnCustom(statement, expectedResult, .{ .pre_statement = null });
+}
+
+const TestOption = struct {
+    /// Pre-run statement.
+    pre_statement: ?[]const u8,
+};
+
+/// Macro function for testing lisp statement and result with options set.
+fn testLispFnCustom(statement: []const u8, expectedResult: []const u8, args: TestOption) !void {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    if (args.pre_statement) |pre_statement| {
+        var reader_pre_statement = Reader.init(allocator, pre_statement);
+        defer reader_pre_statement.deinit();
+
+        _ = try env.apply(reader_pre_statement.ast_root, false);
+    }
+
+    var reader_statement = Reader.init(allocator, statement);
+    defer reader_statement.deinit();
+
+    const reader_statement_value = try env.apply(reader_statement.ast_root, false);
+    defer reader_statement_value.decref();
+
+    const result = printer.pr_str(reader_statement_value, true);
+    try testing.expectEqualStrings(expectedResult, result);
+}
+
+//----------Preset function ends-------------
+
 test {
     var leaking_gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const leaking_allocator = leaking_gpa.allocator();
@@ -22,626 +58,136 @@ test {
     try logz.setup(leaking_allocator, .{ .pool_size = 5, .level = .None });
 }
 
+// NOTE: To skip certain test, add the following into the corresponding
+// test
+// if (true) return error.SkipZigTest;
+
 test "plus function - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var plus_statement = Reader.init(allocator, "(+ 1 2 3)");
-    defer plus_statement.deinit();
-
-    // TODO: Can we handle deinit case in general for apply case?
-    const plus_statement_value = try env.apply(plus_statement.ast_root, false);
-    defer plus_statement_value.decref();
-
-    const result = printer.pr_str(plus_statement_value, true);
-    try testing.expectEqualStrings("6", result);
+    try testLispFn("(+ 1 2 3)", "6");
 }
 
 test "def function - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    const def_statement = Reader.init(allocator, "(def! a 1)");
-    defer def_statement.deinit();
-
-    try testing.expect(def_statement.ast_root.* == .list);
-
-    const def_statement_value = try env.apply(def_statement.ast_root, false);
-    defer def_statement_value.decref();
-
-    const result = printer.pr_str(def_statement_value, true);
-    try testing.expectEqualStrings("1", result);
+    try testLispFn("(def! a 1)", "1");
 }
 
 test "def function - with list eval case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var def_statment = Reader.init(allocator, "(def! a (+ 2 1))");
-    defer def_statment.deinit();
-
-    try testing.expect(def_statment.ast_root.* == .list);
-
-    const def_statement_value = try env.apply(def_statment.ast_root, false);
-    // TODO: Double free now
-    defer def_statement_value.decref();
-
-    const result = printer.pr_str(def_statement_value, true);
-    try testing.expectEqualStrings("3", result);
+    try testLispFn("(def! a (+ 2 1))", "3");
 }
 
 test "let* function - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var letx_statement = Reader.init(allocator, "(let* ((a 2)) (+ a 3))");
-    defer letx_statement.deinit();
-
-    try testing.expect(letx_statement.ast_root.* == .list);
-
-    const letx_statement_value = try env.apply(letx_statement.ast_root, false);
-    defer letx_statement_value.decref();
-
-    const result = printer.pr_str(letx_statement_value, true);
-    try testing.expectEqualStrings("5", result);
+    try testLispFn("(let* ((a 2)) (+ a 3))", "5");
 }
 
 test "let* function - multiple let* case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var letx_statement = Reader.init(allocator, "(let* ((a 2)) (let* ((b 3)) (+ a b)))");
-    defer letx_statement.deinit();
-
-    try testing.expect(letx_statement.ast_root.* == .list);
-
-    const letx_statement_value = try env.apply(letx_statement.ast_root, false);
-    defer letx_statement_value.decref();
-
-    const result = printer.pr_str(letx_statement_value, true);
-    try testing.expectEqualStrings("5", result);
+    try testLispFn("(let* ((a 2)) (let* ((b 3)) (+ a b)))", "5");
 }
 
 test "if function - normal truthy case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var if_statement = Reader.init(allocator, "(if (= 2 2) (+ 1 1) (+ 10 0))");
-    defer if_statement.deinit();
-
-    try testing.expect(if_statement.ast_root.* == .list);
-
-    const if_statement_value = try env.apply(if_statement.ast_root, false);
-    defer if_statement_value.decref();
-
-    const result = printer.pr_str(if_statement_value, true);
-    try testing.expectEqualStrings("2", result);
+    try testLispFn("(if (= 2 2) (+ 1 1) (+ 10 0))", "2");
 }
 
 test "if function - normal falsy case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var if_statement = Reader.init(allocator, "(if (= 2 1) (+ 1 1) (+ 10 0))");
-    defer if_statement.deinit();
-
-    try testing.expect(if_statement.ast_root.* == .list);
-
-    const if_statement_value = try env.apply(if_statement.ast_root, false);
-    defer if_statement_value.decref();
-
-    const result = printer.pr_str(if_statement_value, true);
-    try testing.expectEqualStrings("10", result);
+    try testLispFn("(if (= 2 1) (+ 1 1) (+ 10 0))", "10");
 }
 
 test "if function - incompleted truthy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var if_statement = Reader.init(allocator, "(if (= 2 2) 1)");
-    defer if_statement.deinit();
-
-    try testing.expect(if_statement.ast_root.* == .list);
-
-    const if_statement_value = try env.apply(if_statement.ast_root, false);
-    defer if_statement_value.decref();
-
-    const result = printer.pr_str(if_statement_value, true);
-    try testing.expectEqualStrings("1", result);
+    try testLispFn("(if (= 2 2) 1)", "1");
 }
 
 test "if function - non-boolean case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var if_statement = Reader.init(allocator, "(if 91 (+ 1 1) (+ 1 0))");
-    defer if_statement.deinit();
-
-    try testing.expect(if_statement.ast_root.* == .list);
-
-    const if_statement_value = try env.apply(if_statement.ast_root, false);
-    defer if_statement_value.decref();
-
-    const result = printer.pr_str(if_statement_value, true);
-    try testing.expectEqualStrings("2", result);
+    try testLispFn("(if 91 (+ 1 1) (+ 1 0))", "2");
 }
 
-// NOTE: Need manual deinit previously as it the lambda function
-// does not resolve at all.
-// This makes the program has the potential leakage issue as
-// the interrupter may store the function lisp value but never
-// free.
-// This is due to the ast_root is in list type, in that layer
-// the lambda is not evaled but after the apply function, which
-// makes the normal deinit function does not free the function lisp value.
-// Current implementation checks if the lambda function run and
-// defer deinit process.
-//
-// Using wrap to call lambda function shall consider one of the
-// special case now as it breaks the normal rule to eval list.
-// In Emacs using funcall to supply params is a more standard way
-// in lisp semantic.
-// i.e. (funcall (lambda (a b) (+ 1 a b)) a b)
-//       ^       ^----------------------^ ^ ^
-//  function call   The function part      params
-//              vv----------------------v v v
-// Current case ((lambda (a b) (+ 1 a b)) a b)
 test "lambda function - non-executed case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var lambda_statement = Reader.init(allocator, "(lambda (a) (+ 1 a))");
-    defer lambda_statement.deinit();
-
-    try testing.expect(lambda_statement.ast_root.* == .list);
-
-    const lambda_statement_value = try env.apply(lambda_statement.ast_root, false);
-    defer lambda_statement_value.decref();
-    try testing.expect(lambda_statement_value.* == .function);
-
-    const result = printer.pr_str(lambda_statement_value, true);
-    try testing.expectEqualStrings("#<function>", result);
+    try testLispFn("(lambda (a) (+ 1 a))", "#<function>");
 }
 
 test "lambda function - simple case - single variable" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var lambda_statement = Reader.init(allocator, "((lambda (a) (+ 1 a)) 2)");
-    defer lambda_statement.deinit();
-
-    try testing.expect(lambda_statement.ast_root.* == .list);
-
-    const lambda_statement_value = try env.apply(lambda_statement.ast_root, false);
-    defer lambda_statement_value.decref();
-
-    const result = printer.pr_str(lambda_statement_value, true);
-    try testing.expectEqualStrings("3", result);
+    try testLispFn("((lambda (a) (+ 1 a)) 2)", "3");
 }
 
 test "lambda function - simple case - multiple variables" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var lambda_statement = Reader.init(allocator, "((lambda (a b) (+ 1 a b)) 2 3)");
-    defer lambda_statement.deinit();
-
-    try testing.expect(lambda_statement.ast_root.* == .list);
-
-    const lambda_statement_value = try env.apply(lambda_statement.ast_root, false);
-    defer lambda_statement_value.decref();
-
-    const result = printer.pr_str(lambda_statement_value, true);
-    try testing.expectEqualStrings("6", result);
+    try testLispFn("((lambda (a b) (+ 1 a b)) 2 3)", "6");
 }
 
 test "list function - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var list_statement = Reader.init(allocator, "(list 1 2)");
-    defer list_statement.deinit();
-
-    try testing.expect(list_statement.ast_root.* == .list);
-
-    const list_statement_value = try env.apply(list_statement.ast_root, false);
-    defer list_statement_value.decref();
-
-    const result = printer.pr_str(list_statement_value, true);
-    try testing.expectEqualStrings("(1 2)", result);
+    try testLispFn("(list 1 2)", "(1 2)");
 }
 
 test "list function - string type case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var list_statement = Reader.init(allocator, "(list \"1\")");
-    defer list_statement.deinit();
-
-    try testing.expect(list_statement.ast_root.* == .list);
-
-    const list_statement_value = try env.apply(list_statement.ast_root, false);
-    defer list_statement_value.decref();
-
-    const result = printer.pr_str(list_statement_value, true);
-    try testing.expectEqualStrings("(\"1\")", result);
+    try testLispFn("(list \"1\")", "(\"1\")");
 }
 
-test "list function  - multiple type case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var list_statement = Reader.init(allocator, "(list 1 2 \"1\")");
-    defer list_statement.deinit();
-
-    try testing.expect(list_statement.ast_root.* == .list);
-
-    const list_statement_value = try env.apply(list_statement.ast_root, false);
-    defer list_statement_value.decref();
-
-    const result = printer.pr_str(list_statement_value, true);
-    try testing.expectEqualStrings("(1 2 \"1\")", result);
+test "list function - multiple type case" {
+    try testLispFn("(list 1 2 \"1\")", "(1 2 \"1\")");
 }
 
 test "list function - simple list in list case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var list_statement = Reader.init(allocator, "(list (list 3 4))");
-    defer list_statement.deinit();
-
-    try testing.expect(list_statement.ast_root.* == .list);
-
-    const list_statement_value = try env.apply(list_statement.ast_root, false);
-    defer list_statement_value.deinit();
-
-    const result = printer.pr_str(list_statement_value, true);
-    try testing.expectEqualStrings("((3 4))", result);
+    try testLispFn("(list (list 3 4))", "((3 4))");
 }
 
 test "list function - list in list case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var list_statement = Reader.init(allocator, "(list (list 3 4) 1 2)");
-    defer list_statement.deinit();
-
-    try testing.expect(list_statement.ast_root.* == .list);
-
-    const list_statement_value = try env.apply(list_statement.ast_root, false);
-    defer list_statement_value.decref();
-
-    const result = printer.pr_str(list_statement_value, true);
-    try testing.expectEqualStrings("((3 4) 1 2)", result);
+    try testLispFn("(list (list 3 4) 1 2)", "((3 4) 1 2)");
 }
 
 test "listp function - truthy case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var listp_statement = Reader.init(allocator, "(listp (list 1 2))");
-    defer listp_statement.deinit();
-
-    try testing.expect(listp_statement.ast_root.* == .list);
-
-    const listp_statement_value = try env.apply(listp_statement.ast_root, false);
-    defer listp_statement_value.decref();
-
-    const result = printer.pr_str(listp_statement_value, true);
-    try testing.expectEqualStrings("t", result);
+    try testLispFn("(listp (list 1 2))", "t");
 }
 
 test "listp function - falsy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var listp_statement = Reader.init(allocator, "(listp nil)");
-    defer listp_statement.deinit();
-
-    try testing.expect(listp_statement.ast_root.* == .list);
-
-    const listp_statement_value = try env.apply(listp_statement.ast_root, false);
-    defer listp_statement_value.decref();
-
-    const result = printer.pr_str(listp_statement_value, true);
-    try testing.expectEqualStrings("nil", result);
+    try testLispFn("(listp nil)", "nil");
 }
 
 test "emptyp function - truthy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var emptyp_statement = Reader.init(allocator, "(emptyp (list))");
-    defer emptyp_statement.deinit();
-
-    try testing.expect(emptyp_statement.ast_root.* == .list);
-
-    const emptyp_statement_value = try env.apply(emptyp_statement.ast_root, false);
-    emptyp_statement_value.decref();
-
-    const result = printer.pr_str(emptyp_statement_value, true);
-    try testing.expectEqualStrings("t", result);
+    try testLispFn("(emptyp (list))", "t");
 }
 
 test "emptyp function - falsy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var emptyp_statement = Reader.init(allocator, "(emptyp (list 1))");
-    defer emptyp_statement.deinit();
-
-    try testing.expect(emptyp_statement.ast_root.* == .list);
-
-    const emptyp_statement_value = try env.apply(emptyp_statement.ast_root, false);
-    emptyp_statement_value.decref();
-
-    const result = printer.pr_str(emptyp_statement_value, true);
-    try testing.expectEqualStrings("nil", result);
+    try testLispFn("(emptyp (list 1))", "nil");
 }
 
 test "count function" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var count_statement = Reader.init(allocator, "(count (list 1 2 \"1\"))");
-    defer count_statement.deinit();
-
-    try testing.expect(count_statement.ast_root.* == .list);
-
-    const count_statement_value = try env.apply(count_statement.ast_root, false);
-    defer count_statement_value.deinit();
-
-    const result = printer.pr_str(count_statement_value, true);
-    try testing.expectEqualStrings("3", result);
+    try testLispFn("(count (list 1 2 \"1\"))", "3");
 }
 
 test "[] syntax to create vector - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var vector_statement = Reader.init(allocator, "[1 2]");
-    defer vector_statement.deinit();
-
-    try testing.expect(vector_statement.ast_root.* == .list);
-
-    // NOTE: This is not a primitive value, thus require manual deinit.
-    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
-    defer vector_statement_value.deinit();
-
-    const result = printer.pr_str(vector_statement_value, true);
-    try testing.expectEqualStrings("[1 2]", result);
+    try testLispFn("[1 2]", "[1 2]");
 }
 
 test "vector function - simple case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var vector_statement = Reader.init(allocator, "(vector 1 2)");
-    defer vector_statement.deinit();
-
-    try testing.expect(vector_statement.ast_root.* == .list);
-
-    // NOTE: This is not a primitive value, thus require manual deinit.
-    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
-    defer vector_statement_value.deinit();
-
-    const result = printer.pr_str(vector_statement_value, true);
-    try testing.expectEqualStrings("[1 2]", result);
+    try testLispFn("(vector 1 2)", "[1 2]");
 }
 
 test "vector function - simple symbol case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var vector_statement = Reader.init(allocator, "(vector a)");
-    defer vector_statement.deinit();
-
-    try testing.expect(vector_statement.ast_root.* == .list);
-
-    // NOTE: This is not a primitive value, thus require manual deinit.
-    const vector_statement_value = try env.apply(vector_statement.ast_root, false);
-    defer vector_statement_value.deinit();
-
-    const result = printer.pr_str(vector_statement_value, true);
-    try testing.expectEqualStrings("[a]", result);
+    try testLispFn("(vector a)", "[a]");
 }
 
 test "vectorp function - truthy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var vectorp_statement = Reader.init(allocator, "(vectorp (vector 1 2))");
-    defer vectorp_statement.deinit();
-
-    try testing.expect(vectorp_statement.ast_root.* == .list);
-
-    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root, false);
-    defer vectorp_statement_value.decref();
-
-    const result = printer.pr_str(vectorp_statement_value, true);
-    try testing.expectEqualStrings("t", result);
+    try testLispFn("(vectorp (vector 1 2))", "t");
 }
 
 test "vectorp function - falsy case" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var vectorp_statement = Reader.init(allocator, "(vectorp nil)");
-    defer vectorp_statement.deinit();
-
-    try testing.expect(vectorp_statement.ast_root.* == .list);
-
-    const vectorp_statement_value = try env.apply(vectorp_statement.ast_root, false);
-    defer vectorp_statement_value.decref();
-
-    const result = printer.pr_str(vectorp_statement_value, true);
-    try testing.expectEqualStrings("nil", result);
+    try testLispFn("(vectorp nil)", "nil");
 }
 
 test "vectorp function - through let* to create variable case" {
-    // if (true) return error.SkipZigTest;
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var is_vector_var_statement = Reader.init(
-        allocator,
-        "(let* ((vector_param (vector 1 2))) (vectorp vector_param))",
-    );
-    defer is_vector_var_statement.deinit();
-
-    const is_vector_var_statement_value = try env.apply(is_vector_var_statement.ast_root, false);
-    defer is_vector_var_statement_value.decref();
-
-    const result = printer.pr_str(is_vector_var_statement_value, true);
-    try testing.expectEqualStrings("t", result);
-
-    const is_vector_var_statement_value_bool = is_vector_var_statement_value.as_boolean() catch unreachable;
-    try testing.expectEqual(true, is_vector_var_statement_value_bool);
+    try testLispFn("(let* ((vector_param (vector 1 2))) (vectorp vector_param))", "t");
 }
 
 test "aref function - direct get from vector constructor" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var aref_statement = Reader.init(allocator, "(aref [1 2 3] 1)");
-    defer aref_statement.deinit();
-
-    try testing.expect(aref_statement.ast_root.* == .list);
-
-    const aref_statement_value = try env.apply(aref_statement.ast_root, false);
-    defer aref_statement_value.decref();
-
-    const result = printer.pr_str(aref_statement_value, true);
-    try testing.expectEqualStrings("2", result);
+    try testLispFn("(aref [1 2 3] 1)", "2");
 }
 
 test "aref function - get from variable" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var def_statement = Reader.init(allocator, "(def! a [1 2 3])");
-    defer def_statement.deinit();
-
-    _ = try env.apply(def_statement.ast_root, false);
-
-    var aref_statement = Reader.init(allocator, "(aref a 1)");
-    defer aref_statement.deinit();
-
-    try testing.expect(aref_statement.ast_root.* == .list);
-
-    const aref_statement_value = try env.apply(aref_statement.ast_root, false);
-    defer aref_statement_value.decref();
-
-    const result = printer.pr_str(aref_statement_value, true);
-    try testing.expectEqualStrings("2", result);
+    try testLispFnCustom("(aref a 1)", "2", .{
+        .pre_statement = "(def! a [1 2 3]) ",
+    });
 }
 
 test "pr-str function" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var pr_str_statement = Reader.init(allocator, "(pr-str \"\\\"\")");
-    defer pr_str_statement.deinit();
-
-    const pr_str_statement_value = try env.apply(pr_str_statement.ast_root, false);
-    defer pr_str_statement_value.decref();
-
-    const result = printer.pr_str(pr_str_statement_value, true);
-    try testing.expectEqualStrings("\"\\\"\\\\\\\"\\\"\"", result);
+    try testLispFn("(pr-str \"\\\"\")", "\"\\\"\\\\\\\"\\\"\"");
 }
 
 test "str function" {
-    const allocator = testing.allocator;
-
-    const env = LispEnv.init_root(allocator);
-    defer env.deinit();
-
-    var str_statement = Reader.init(allocator, "(str \"\\\"\")");
-    defer str_statement.deinit();
-
-    const str_statement_value = try env.apply(str_statement.ast_root, false);
-    defer str_statement_value.decref();
-
-    const result = printer.pr_str(str_statement_value, true);
-    try testing.expectEqualStrings("\"\\\"\"", result);
+    try testLispFn("(str \"\\\"\")", "\"\\\"\"");
 }

--- a/tests/testing_lisp_general_ptr.zig
+++ b/tests/testing_lisp_general_ptr.zig
@@ -613,3 +613,35 @@ test "aref function - get from variable" {
     const result = printer.pr_str(aref_statement_value, true);
     try testing.expectEqualStrings("2", result);
 }
+
+test "pr-str function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var pr_str_statement = Reader.init(allocator, "(pr-str \"\\\"\")");
+    defer pr_str_statement.deinit();
+
+    const pr_str_statement_value = try env.apply(pr_str_statement.ast_root, false);
+    defer pr_str_statement_value.decref();
+
+    const result = printer.pr_str(pr_str_statement_value, true);
+    try testing.expectEqualStrings("\"\\\"\\\\\\\"\\\"\"", result);
+}
+
+test "str function" {
+    const allocator = testing.allocator;
+
+    const env = LispEnv.init_root(allocator);
+    defer env.deinit();
+
+    var str_statement = Reader.init(allocator, "(str \"\\\"\")");
+    defer str_statement.deinit();
+
+    const str_statement_value = try env.apply(str_statement.ast_root, false);
+    defer str_statement_value.decref();
+
+    const result = printer.pr_str(str_statement_value, true);
+    try testing.expectEqualStrings("\"\\\"\"", result);
+}


### PR DESCRIPTION
Provide the following printing functions in lisp env
- `pr-str`: Return the string object with in readably form and join with space
- `str`:  Return the string object with in non-readably form and join without space
The following are provided by plugin:
- `prn`: Print out the given params in readably form, join the result with space
- `println`:  Print out the given params in non-readably form, join the result with space

Provide helper macro to help test lisp code for `testing_lisp_general_ptr.zig`.